### PR TITLE
fix: resolve 30 broken internal markdown links across 9 files

### DIFF
--- a/02-ai-agents/google-5-day-ai-agents-course.md
+++ b/02-ai-agents/google-5-day-ai-agents-course.md
@@ -13,7 +13,7 @@ Understand AI agent fundamentals: core architecture, taxonomy of capabilities, a
 [![Day 1 Preview](../assets/guides/google-2026/previews/01%20Introduction%20to%20Agents.png)](../assets/guides/google-2026/01%20Introduction%20to%20Agents.pdf)
 
 > [!NOTE]
-> See also our internal [AI Agents Overview](ai-agents-overview.md) for more context.
+> See also our internal [AI Agents Overview](./ai-agents-overview.md) for more context.
 
 **Resources**
 - [Code Resource 1: From Prompt to Action](https://www.kaggle.com/code/kaggle5daysofai/day-1a-from-prompt-to-action) | [Code Resource 2: Agent Architectures](https://www.kaggle.com/code/kaggle5daysofai/day-1b-agent-architectures)
@@ -28,7 +28,7 @@ Learn how agents interact with external systems through tools and APIs. Understa
 
 
 > [!NOTE]
-> See also our internal [MCP Guide](mcp-guide.md) for more tactics and context.
+> See also our internal [MCP Guide](./mcp-guide.md) for more tactics and context.
 
 **Resources**
 - [Code Resource 1: Agent Tools](https://www.kaggle.com/code/kaggle5daysofai/day-2a-agent-tools) | [Code Resource 2: Agent Tools Best Practices](https://www.kaggle.com/code/kaggle5daysofai/day-2b-agent-tools-best-practices)
@@ -42,7 +42,7 @@ Discover how agents maintain context across conversations. Understand Sessions f
 [![Day 3 Preview](../assets/guides/google-2026/previews/03%20Context%20Engineering:%20Sessions%20&%20Memory.png)](../assets/guides/google-2026/03%20Context%20Engineering:%20Sessions%20&%20Memory.pdf)
 
 > [!TIP]
-> Compare these approaches with our repository's guide on [Context Engineering](context-engineering.md).
+> Compare these approaches with our repository's guide on [Context Engineering](./context-engineering.md).
 
 **Resources**
 - [Code Resource 1: Agent Sessions](https://www.kaggle.com/code/kaggle5daysofai/day-3a-agent-sessions) | [Code Resource 2: Agent Memory](https://www.kaggle.com/code/kaggle5daysofai/day-3b-agent-memory)
@@ -67,7 +67,7 @@ Understand deployment lifecycle and scaling strategies. Learn Agent2Agent Protoc
 [![Day 5 Preview](../assets/guides/google-2026/previews/05%20Prototype%20to%20Production.png)](../assets/guides/google-2026/05%20Prototype%20to%20Production.pdf)
 
 > [!NOTE]
-> To understand coordination deeper, read our local [Agent-to-Agent (A2A) Protocol Guide](a2a-protocol-guide.md).
+> To understand coordination deeper, read our local [Agent-to-Agent (A2A) Protocol Guide](./a2a-protocol-guide.md).
 
 **Resources**
 - [Code Resource 1: Agent2Agent Communication](https://www.kaggle.com/code/kaggle5daysofai/day-5a-agent2agent-communication) | [Code Resource 2: Agent Deployment](https://www.kaggle.com/code/kaggle5daysofai/day-5b-agent-deployment)

--- a/02-ai-agents/self-evolving-agents-google-adk.md
+++ b/02-ai-agents/self-evolving-agents-google-adk.md
@@ -261,4 +261,4 @@ This mirrors how software engineers extend a codebase with new modules rather th
 - [5 Agent Skill Design Patterns Every ADK Developer Should Know](https://lavinigam.com/posts/adk-skill-design-patterns/)
 - [Introducing Skills in ADK — Google Cloud Community](https://medium.com/google-cloud/introducing-skills-in-adk-teach-your-agent-new-tricks-one-skill-at-a-time-be319f9b1917)
 - [Google Cloud ADK Quickstart](../05-tools/google-cloud-platform-agents.md)
-- [Claude Agent Skills Playbook](claude-agent-skills.md)
+- [Claude Agent Skills Playbook](./claude-agent-skills.md)

--- a/02-ai-agents/ultimate-2026-ai-software-implementation-guide.md
+++ b/02-ai-agents/ultimate-2026-ai-software-implementation-guide.md
@@ -1,7 +1,7 @@
 # Ultimate 2026 Implementation Guide for AI Software Products
 
 ## Intent
-Provide a 2026-ready implementation playbook for AI products that treats the model context window as a full operating environment. The guide combines [Model Context Protocol (MCP)](mcp-guide.md), modular [Skills](claude-agent-skills.md), and AI Agents into a single [Context Engineering](context-engineering.md) stack.
+Provide a 2026-ready implementation playbook for AI products that treats the model context window as a full operating environment. The guide combines [Model Context Protocol (MCP)](./mcp-guide.md), modular [Skills](./claude-agent-skills.md), and AI Agents into a single [Context Engineering](./context-engineering.md) stack.
 
 ## Use when
 - You are building or refactoring an AI-native product that must interoperate with multiple agents and tools.
@@ -10,21 +10,21 @@ Provide a 2026-ready implementation playbook for AI products that treats the mod
 ## Audience
 Product engineers, solution architects, and AI platform teams shipping agentic experiences.
 
-## [Context Engineering](context-engineering.md) Stack (2026 view)
+## [Context Engineering](./context-engineering.md) Stack (2026 view)
 | Layer | Purpose | Key moves |
 | --- | --- | --- |
-| **[MCP Infrastructure](mcp-guide.md)** | Standardize how models access data, events, and actions via MCP servers. | Ship MCP servers for core domains (identity, documents, transactions) instead of bespoke integrations. Stream only the slices of data an agent needs per turn. |
-| **[Skills (Capability Layer)](claude-agent-skills.md)** | Package a task-specific intent, tool schema, guardrails, and error handling. | Keep skills atomic (Search, Analysis, Code, Review). Attach expert personas and chain-of-thought requirements to each skill. Load skills on-demand to reduce tool noise. |
+| **[MCP Infrastructure](./mcp-guide.md)** | Standardize how models access data, events, and actions via MCP servers. | Ship MCP servers for core domains (identity, documents, transactions) instead of bespoke integrations. Stream only the slices of data an agent needs per turn. |
+| **[Skills (Capability Layer)](./claude-agent-skills.md)** | Package a task-specific intent, tool schema, guardrails, and error handling. | Keep skills atomic (Search, Analysis, Code, Review). Attach expert personas and chain-of-thought requirements to each skill. Load skills on-demand to reduce tool noise. |
 | **AI Agents (Orchestration Layer)** | Manage the context lifecycle, pick skills, and decide when to call MCP resources. | Monitor state, summarize aggressively, and maintain long-term objectives while respecting token limits. |
 
 ## 2026 delivery phases
-### Phase 1: Expose the data with [MCP](mcp-guide.md)
+### Phase 1: Expose the data with [MCP](./mcp-guide.md)
 - Build MCP servers first; UI can follow. Treat every domain surface (files, tickets, metrics, payments) as an MCP Resource or Tool.
 - Normalize schemas so any MCP-compliant agent can use them without custom glue code.
 - Implement streaming filters to minimize context bloat: return only the last N events, scoped by user, project, or time window.
 - Publish a minimal MCP catalog with authentication notes, rate limits, and example invocations.
 
-### Phase 2: Design modular [Skills](claude-agent-skills.md)
+### Phase 2: Design modular [Skills](./claude-agent-skills.md)
 - Group capabilities into loadable skills rather than one monolithic bot.
 - Define crisp **input schemas** (required fields, enums, defaults) and **OUTPUT FORMAT** expectations for every skill.
 - Attach **expert personas** per skill (e.g., "Senior Accountant" for FinancialAnalysisSkill) and include failure recovery guidance.
@@ -45,7 +45,7 @@ Product engineers, solution architects, and AI platform teams shipping agentic e
 4) **Measure**: Track token spend, latency, and success loops. Add telemetry for skill selection and context hit rate.
 5) **Harden**: Apply constraint injection (policy text, limits), red-team prompt tests, and deterministic evaluations for structured outputs.
 
-## [MCP](mcp-guide.md)-first build checklist
+## [MCP](./mcp-guide.md)-first build checklist
 - [ ] MCP servers deployed for every critical domain with smoke-tested schemas.
 - [ ] Streaming and filtering implemented to avoid overfilling the context window.
 - [ ] Skill Registry mapped to MCP resources with versioning and examples.

--- a/05-tools/claude-code-cheatsheet-tutorial.md
+++ b/05-tools/claude-code-cheatsheet-tutorial.md
@@ -200,4 +200,4 @@ REQUEST: Provide a short plan, then implement.
 ## References
 - Claude Code official website: <https://claude.com/product/claude-code>
 - [Everything Claude Code (GitHub)](https://github.com/affaan-m/everything-claude-code)
-- [Claude Code Project Structure Tutorial](claude-code-project-structure-tutorial.md)
+- [Claude Code Project Structure Tutorial](./claude-code-project-structure-tutorial.md)

--- a/05-tools/claude-code-cheatsheet-v2.md
+++ b/05-tools/claude-code-cheatsheet-v2.md
@@ -379,12 +379,12 @@ The following pages from this repository are relevant to this cheat sheet:
 
 ### Claude Code Guides
 
-- [Claude Code Tool Guide](claude-code-tool-guide.md) — Comprehensive guide to Claude Code capabilities and usage
-- [Claude Code Cheatsheet Tutorial](claude-code-cheatsheet-tutorial.md) — Earlier cheatsheet reference (pre-v2.81)
-- [Claude Code Project Structure Tutorial](claude-code-project-structure-tutorial.md) — Best practices for organizing projects in Claude Code
-- [Claude Code Certification Guide](claude-code-certification-guide.md) — Certification path for Claude Code proficiency
-- [Claude Code NotebookLM Integration Tutorial](claude-code-notebooklm-integration-tutorial.md) — Guide for integrating Claude Code with NotebookLM
-- [Claude.ai vs Code vs Cowork](claude-ai-vs-code-vs-cowork.md) — Comparison of Claude.ai, Claude Code, and Cowork tools
+- [Claude Code Tool Guide](./claude-code-tool-guide.md) — Comprehensive guide to Claude Code capabilities and usage
+- [Claude Code Cheatsheet Tutorial](./claude-code-cheatsheet-tutorial.md) — Earlier cheatsheet reference (pre-v2.81)
+- [Claude Code Project Structure Tutorial](./claude-code-project-structure-tutorial.md) — Best practices for organizing projects in Claude Code
+- [Claude Code Certification Guide](./claude-code-certification-guide.md) — Certification path for Claude Code proficiency
+- [Claude Code NotebookLM Integration Tutorial](./claude-code-notebooklm-integration-tutorial.md) — Guide for integrating Claude Code with NotebookLM
+- [Claude.ai vs Code vs Cowork](./claude-ai-vs-code-vs-cowork.md) — Comparison of Claude.ai, Claude Code, and Cowork tools
 - [Claude Building Skills Guide](../04-guides/claude-building-skills-guide.md) — Guide for building custom skills with Claude
 
 ### AI Agents & MCP
@@ -398,10 +398,10 @@ The following pages from this repository are relevant to this cheat sheet:
 
 ### Coding & Spec-Driven Development
 
-- [Spec-Driven Development Tutorial](spec-driven-development-tutorial.md) — Tutorial for spec-driven development approach
-- [Spec-Driven Development AI Tutorial](spec-driven-development-ai-tutorial.md) — AI-specific spec-driven development guide
-- [Coding AI Agent Selection Tutorial](coding-ai-agent-selection-tutorial.md) — Framework for selecting appropriate coding AI agents
-- [AI Tool Chaining](ai-tool-chaining-oct-2025.md) — Chaining multiple AI tools together
+- [Spec-Driven Development Tutorial](./spec-driven-development-tutorial.md) — Tutorial for spec-driven development approach
+- [Spec-Driven Development AI Tutorial](./spec-driven-development-ai-tutorial.md) — AI-specific spec-driven development guide
+- [Coding AI Agent Selection Tutorial](./coding-ai-agent-selection-tutorial.md) — Framework for selecting appropriate coding AI agents
+- [AI Tool Chaining](./ai-tool-chaining-oct-2025.md) — Chaining multiple AI tools together
 
 ### Prompt Patterns
 

--- a/05-tools/claude-code-project-structure-tutorial.md
+++ b/05-tools/claude-code-project-structure-tutorial.md
@@ -305,9 +305,9 @@ Configure via `.mcp.json`:
 
 ## 9. Related Resources
 - **[Claude Agent Skills Playbook](../02-ai-agents/claude-agent-skills.md)** — Dive deeper into building reusable workflows.
-- **[Claude AI vs Claude Code vs Claude Cowork](claude-ai-vs-code-vs-cowork.md)** — Understand which tool fits your specific use case.
-- **[Claude Code Tool Guide](claude-code-tool-guide.md)** — Explore additional automation commands and configurations.
-- **[Claude Code Cheatsheet Tutorial](claude-code-cheatsheet-tutorial.md)** — Keep the essential commands handy.
+- **[Claude AI vs Claude Code vs Claude Cowork](./claude-ai-vs-code-vs-cowork.md)** — Understand which tool fits your specific use case.
+- **[Claude Code Tool Guide](./claude-code-tool-guide.md)** — Explore additional automation commands and configurations.
+- **[Claude Code Cheatsheet Tutorial](./claude-code-cheatsheet-tutorial.md)** — Keep the essential commands handy.
 - **[Model Context Protocol (MCP) Guide](../02-ai-agents/mcp-guide.md)** — Learn how to configure robust external tool connections.
 
 ## References

--- a/05-tools/copilot-prompt-template.md
+++ b/05-tools/copilot-prompt-template.md
@@ -67,5 +67,5 @@ I want a {goal} for {context}. Respond in {expectations} and use {source}.
 - "Write a future-looking narrative about our product strategy grounded in insights from the Q1 leadership summit notes. Keep it to three short paragraphs."
 
 ## Related Resources
-- [Microsoft Copilot Agents Blueprint](microsoft-copilot-agents.md)
+- [Microsoft Copilot Agents Blueprint](./microsoft-copilot-agents.md)
 - [Guide to Prompt Pattern Catalogue](../03-prompts-and-patterns/prompt-pattern-catalogue.md)

--- a/05-tools/microsoft-copilot-researcher-agent.md
+++ b/05-tools/microsoft-copilot-researcher-agent.md
@@ -45,7 +45,7 @@ Pull ready-to-run scenarios from the Microsoft M365 Copilot prompting guide to a
 ### Share across teams
 - Drop these starters into your Copilot Researcher instructions library so new collaborators can test common workflows immediately.
 - Point business partners to the [Copilot Prompt Gallery](https://m365.cloud.microsoft/copilot-prompts) for additional Microsoft-curated prompts they can bookmark inside Copilot Chat.
-- Reference the [Microsoft 365 Copilot Prompting Guide](microsoft-365-copilot-prompting-guide.md) for full do/don’t lists, evaluation rubric, and long-document tactics.
+- Reference the [Microsoft 365 Copilot Prompting Guide](./microsoft-365-copilot-prompting-guide.md) for full do/don’t lists, evaluation rubric, and long-document tactics.
 
 ## Reasoning prompt patterns from GPT-Lab
 The GPT-Lab resource “Effective Prompts for Reasoning LLMs” highlights patterns that pair exceptionally well with Copilot Researcher’s long-context and document-grounding capabilities. Keep the examples verbatim inside your instructions or prompt library so reviewers can trace external sourcing.

--- a/05-tools/notebooklm-2026-tool-tutorial.md
+++ b/05-tools/notebooklm-2026-tool-tutorial.md
@@ -208,5 +208,5 @@ Studio plan: Audio overview (Debate) + flashcards (medium) + quiz (10 questions)
 - Share the notebook or chat depending on what you want to reveal.
 
 ## References
-- [NotebookLM Audio Overviews Blueprint](notebooklm-audio-overviews-blueprint.md)
-- [NotebookLM Prompting Blueprints](notebooklm-prompting-blueprints.md)
+- [NotebookLM Audio Overviews Blueprint](./notebooklm-audio-overviews-blueprint.md)
+- [NotebookLM Prompting Blueprints](./notebooklm-prompting-blueprints.md)

--- a/agents.md
+++ b/agents.md
@@ -132,6 +132,7 @@ If a command fails, capture the error, suggest a minimal fix, and avoid broad de
 ## 6. Navigation & documentation site
 - The documentation site uses **MkDocs Material**. Only adjust `mkdocs.yml` to add or rename pages you touch.
 - Use relative links inside Markdown. Prefer fenced code blocks for commands.
+- **Always use explicit relative paths for internal links.** Same-directory links must start with `./` (e.g. `[MCP Guide](./mcp-guide.md)`, not `[MCP Guide](mcp-guide.md)`). Cross-directory links use `../` as appropriate. Bare filenames are not resolved correctly by MkDocs and will produce broken links on the docs site.
 - Provide screenshots or sample outputs when altering navigation or visual assets.
 
 ---


### PR DESCRIPTION
All broken links used bare filenames (e.g. mcp-guide.md) instead of
explicit relative paths (./mcp-guide.md), which MkDocs does not resolve
correctly from within subdirectories.

Also adds the ./prefix convention to agents.md section 6 so the root
cause does not recur.

https://claude.ai/code/session_01LQw1iMrfZ2VbXqJouBsF1H