### PR TITLE
fix: resolve broken links, add front-matter metadata, and update contributor guidelines

### DIFF
--- a/02-ai-agents/a2a-protocol-guide.md
+++ b/02-ai-agents/a2a-protocol-guide.md
@@ -1,3 +1,9 @@
+---
+title: "Agent-to-Agent (A2A) Protocol Guide"
+tags: ["agents", "a2a-protocol"]
+last_updated: "2026-01-10"
+---
+
 # Agent-to-Agent (A2A) Protocol Guide
 
 ## Intent

--- a/02-ai-agents/ai-agents-overview.md
+++ b/02-ai-agents/ai-agents-overview.md
@@ -1,3 +1,9 @@
+---
+title: "AI Agents Overview"
+tags: ["agents"]
+last_updated: "2026-01-10"
+---
+
 # Understanding AI Agents
 
 ## Overview

--- a/02-ai-agents/ai-coding-spectrum.md
+++ b/02-ai-agents/ai-coding-spectrum.md
@@ -1,3 +1,9 @@
+---
+title: "AI Coding Spectrum"
+tags: ["agents", "coding-spectrum"]
+last_updated: "2026-01-10"
+---
+
 # AI Coding Spectrum
 
 ## Intent

--- a/02-ai-agents/claude-agent-skills.md
+++ b/02-ai-agents/claude-agent-skills.md
@@ -1,3 +1,9 @@
+---
+title: "Claude Agent Skills Playbook"
+tags: ["agents", "claude-agent"]
+last_updated: "2026-02-28"
+---
+
 <img src="../assets/anthropic/claude-agent-skills.svg" alt="Claude Agent Skills" width="80%">
 
 # Claude Agent Skills Playbook

--- a/02-ai-agents/claude-managed-agents-tutorial.md
+++ b/02-ai-agents/claude-managed-agents-tutorial.md
@@ -1,3 +1,9 @@
+---
+title: "Claude Managed Agents Tutorial"
+tags: ["agents", "claude-managed"]
+last_updated: "2026-04-10"
+---
+
 # Claude Managed Agents Tutorial
 
 ## Intent

--- a/02-ai-agents/context-engineering.md
+++ b/02-ai-agents/context-engineering.md
@@ -1,3 +1,9 @@
+---
+title: "Context Engineering"
+tags: ["agents", "context-engineering"]
+last_updated: "2026-01-10"
+---
+
 # Context Engineering
 
 ![Context engineering overview](../assets/other/context-engineering.PNG)

--- a/02-ai-agents/cursor-dynamic-context-discovery.md
+++ b/02-ai-agents/cursor-dynamic-context-discovery.md
@@ -1,3 +1,9 @@
+---
+title: "Cursor Dynamic Context Discovery"
+tags: ["agents", "cursor-dynamic"]
+last_updated: "2026-01-10"
+---
+
 # Cursor Dynamic Context Discovery (Context Engineering Guide)
 
 ## Overview

--- a/02-ai-agents/google-5-day-ai-agents-course.md
+++ b/02-ai-agents/google-5-day-ai-agents-course.md
@@ -1,3 +1,9 @@
+---
+title: "Google 5-Day AI Agents Intensive Course"
+tags: ["agents", "google-day"]
+last_updated: "2026-04-22"
+---
+
 # Google 5-Day AI Agents Intensive Course
 
 ![Google AI Agents Course](../assets/guides/google-2026/google-ai-agent-course.jpeg)

--- a/02-ai-agents/mcp-guide.md
+++ b/02-ai-agents/mcp-guide.md
@@ -1,3 +1,9 @@
+---
+title: "Model Context Protocol (MCP) Guide"
+tags: ["agents", "mcp"]
+last_updated: "2026-01-11"
+---
+
 # Model Context Protocol (MCP) Guide
 
 ## Intent

--- a/02-ai-agents/mempalace-ai-memory-tutorial.md
+++ b/02-ai-agents/mempalace-ai-memory-tutorial.md
@@ -1,3 +1,9 @@
+---
+title: "MemPalace: AI Memory System Tutorial"
+tags: ["agents", "mempalace-memory"]
+last_updated: "2026-04-08"
+---
+
 # MemPalace: AI Memory System Tutorial
 
 ## Why Memory Is the Missing Layer of Intelligence

--- a/02-ai-agents/models-for-ai-agents-2026.md
+++ b/02-ai-agents/models-for-ai-agents-2026.md
@@ -1,3 +1,9 @@
+---
+title: "Best Model Providers for AI Agents for 2026"
+tags: ["agents", "models-agents"]
+last_updated: "2026-01-10"
+---
+
 # Best Model Providers for AI Agents for 2026
 
 ## Intent

--- a/02-ai-agents/open-models.md
+++ b/02-ai-agents/open-models.md
@@ -1,3 +1,9 @@
+---
+title: "Open Models for Agentic AI"
+tags: ["agents", "open-models"]
+last_updated: "2026-01-10"
+---
+
 # Open Models for Agentic AI: Why Openness Accelerates Innovation
 
 ## The core idea

--- a/02-ai-agents/self-evolving-agents-google-adk.md
+++ b/02-ai-agents/self-evolving-agents-google-adk.md
@@ -1,3 +1,9 @@
+---
+title: "Self-Evolving AI with Google ADK and Agent Skills"
+tags: ["agents", "self-evolving"]
+last_updated: "2026-04-22"
+---
+
 <img src="../assets/other/self-evolving-ai.png" alt="Google ADK Self-Evolving Agents" width="80%">
 
 # Self-Evolving AI: Scaling Autonomy with Google ADK and Agent Skills

--- a/02-ai-agents/ultimate-2026-ai-software-implementation-guide.md
+++ b/02-ai-agents/ultimate-2026-ai-software-implementation-guide.md
@@ -1,3 +1,9 @@
+---
+title: "Ultimate 2026 AI Software Implementation Guide"
+tags: ["agents", "ultimate-software"]
+last_updated: "2026-04-22"
+---
+
 # Ultimate 2026 Implementation Guide for AI Software Products
 
 ## Intent

--- a/03-prompts-and-patterns/managers-prompting-blueprints.md
+++ b/03-prompts-and-patterns/managers-prompting-blueprints.md
@@ -1,3 +1,11 @@
+---
+title: "Managers Prompting Blueprints"
+intent: ""
+model_tested: []
+tags: ["patterns", "managers-blueprints"]
+last_updated: "2026-01-10"
+---
+
 <img src="../assets/openai/openai_academy1.jpeg" alt="OpenAI Academy" width="80%">
 
 # Prompting Blueprints for Managers

--- a/03-prompts-and-patterns/presentations-prompting-blueprints.md
+++ b/03-prompts-and-patterns/presentations-prompting-blueprints.md
@@ -1,3 +1,11 @@
+---
+title: "Presentations Prompting Blueprints (Patrick Winston)"
+intent: ""
+model_tested: []
+tags: ["patterns", "presentations-blueprints"]
+last_updated: "2026-04-09"
+---
+
 # Claude Can Now Prepare Your Presentations Using the Exact Framework Patrick Winston Taught MIT Students for 40 Years
 
 Patrick Winston spent four decades teaching MIT students how to give talks that change minds. His framework is precise, ruthless, and built around one principle: every element of a presentation either serves the audience or wastes their time. There is no middle ground.

--- a/03-prompts-and-patterns/prompt-pattern-catalogue.md
+++ b/03-prompts-and-patterns/prompt-pattern-catalogue.md
@@ -1,3 +1,11 @@
+---
+title: "Guide to Prompt Pattern Catalogue"
+intent: ""
+model_tested: []
+tags: ["patterns", "pattern-catalogue"]
+last_updated: "2026-01-10"
+---
+
 # Guide to Prompt Pattern Catalogue
 
 This guide summarizes seven prompting patterns from Dr. Jules White's research on prompting blueprints and explains when and how to apply them in practice. Each section provides a quick diagnostic for when the pattern is useful, a step-by-step workflow, and an example scaffold you can adapt in your own prompts.

--- a/03-prompts-and-patterns/researchers-prompting-blueprints.md
+++ b/03-prompts-and-patterns/researchers-prompting-blueprints.md
@@ -1,3 +1,11 @@
+---
+title: "Researchers Prompting Blueprints"
+intent: "Provide academic researchers with ready-to-use prompting patterns that improve clarity, rigor, and collaboration when working with reasoning-focused language models."
+model_tested: []
+tags: ["patterns", "researchers-blueprints"]
+last_updated: "2026-01-10"
+---
+
 # Researchers Prompting Blueprints
 
 ## Intent

--- a/03-prompts-and-patterns/weekly-newsletter-blueprint.md
+++ b/03-prompts-and-patterns/weekly-newsletter-blueprint.md
@@ -1,3 +1,11 @@
+---
+title: "Weekly Newsletter Blueprint"
+intent: ""
+model_tested: []
+tags: ["patterns", "weekly-newsletter"]
+last_updated: "2026-01-10"
+---
+
 # Weekly Newsletter Automation for your [*TOPIC*]
 
 This guide shows you how to set up a **weekly, scheduled newsletter workflow** inside ChatGPT that searches the web every Thursday at **09:00 GMT**, selects the strongest stories, and produces three outputs you can share immediately: concise newsletter blurbs, a LinkedIn post, and a short SEO article.

--- a/03-prompts-and-patterns/writers-prompting-blueprints.md
+++ b/03-prompts-and-patterns/writers-prompting-blueprints.md
@@ -1,3 +1,11 @@
+---
+title: "Writers Prompting Blueprints"
+intent: "Equip writers and editors with ready-to-use prompting scaffolds that enforce editorial standards while leveraging reasoning-capable LLMs for drafting, revising, and polishing long-form or short-form c"
+model_tested: []
+tags: ["patterns", "writers-blueprints"]
+last_updated: "2026-01-10"
+---
+
 # Writers Prompting Blueprints
 
 ## Intent

--- a/04-guides/ai-adoption-guide.md
+++ b/04-guides/ai-adoption-guide.md
@@ -1,3 +1,9 @@
+---
+title: "AI Adoption Readiness Guide"
+tags: ["guides", "adoption"]
+last_updated: "2026-01-10"
+---
+
 # AI Adoption Readiness Guide
 
 ## Intent

--- a/04-guides/ai-gone-wrong-stories.md
+++ b/04-guides/ai-gone-wrong-stories.md
@@ -1,3 +1,9 @@
+---
+title: "AI Gone Wrong Incident Stories"
+tags: ["guides", "gone-wrong"]
+last_updated: "2026-01-10"
+---
+
 <img src="../assets/ai-gone-wrong/ai-gone-wrong-1.png" alt="AI Gone Wrong" width="80%">
 
 # AI Gone Wrong Incident Stories

--- a/04-guides/claude-building-skills-guide.md
+++ b/04-guides/claude-building-skills-guide.md
@@ -1,3 +1,9 @@
+---
+title: "Claude Building Skills Guide"
+tags: ["guides", "claude-building"]
+last_updated: "2026-03-15"
+---
+
 # Claude Building Skills Guide
 
 [![Anthropic Claude Skills Guide Preview](../assets/guides/previews/anthropic-claude-skills-guide.png)](../assets/guides/anthropic-claude-skills-guide.pdf)

--- a/04-guides/claude-fine-tune-llm.md
+++ b/04-guides/claude-fine-tune-llm.md
@@ -1,3 +1,9 @@
+---
+title: "Fine-Tune an Open Source LLM with Claude"
+tags: ["guides", "claude-fine"]
+last_updated: "2026-01-10"
+---
+
 # Fine-Tune an Open Source LLM with Claude
 
 ## Intent

--- a/04-guides/codex-agent-prompting-guide.md
+++ b/04-guides/codex-agent-prompting-guide.md
@@ -1,3 +1,9 @@
+---
+title: "Codex Agent Prompting Guide"
+tags: ["guides", "codex-agent"]
+last_updated: "2026-01-10"
+---
+
 # Codex Agent Prompting Guide
 
 ## Intent

--- a/04-guides/finetune-functiongemma.md
+++ b/04-guides/finetune-functiongemma.md
@@ -1,3 +1,9 @@
+---
+title: "FunctionGemma Fine-Tuning + Local Serving (LM Studio)"
+tags: ["guides", "finetune-functiongemma"]
+last_updated: "2026-01-10"
+---
+
 <img src="../assets/google/function-gemma.jpg" alt="FunctionGemma" width="80%">
 
 # FunctionGemma Fine-Tuning + Local Serving (LM Studio)

--- a/04-guides/gemini-n8n-workflow-json-guide.md
+++ b/04-guides/gemini-n8n-workflow-json-guide.md
@@ -1,3 +1,9 @@
+---
+title: "Gemini 3 Pro + n8n Workflow JSON Guide"
+tags: ["guides", "gemini-n8n"]
+last_updated: "2026-01-10"
+---
+
 # Gemini 3 Pro Prompting Guide for n8n Workflow JSON Templates
 
 This guide shows how to prompt **Gemini 3 Pro** to generate an **n8n workflow template in JSON format** that you can import into n8n. It is based on the workflow design approach demonstrated in the tutorial: <https://youtu.be/Vb1SwBAn9cQ>.

--- a/04-guides/gen-ai-project-tutorial.md
+++ b/04-guides/gen-ai-project-tutorial.md
@@ -1,3 +1,9 @@
+---
+title: "Generative AI Project Tutorial"
+tags: ["guides", "gen-project"]
+last_updated: "2026-01-10"
+---
+
 # Generative AI Project Tutorial
 
 ## Intent

--- a/04-guides/genai-basics-glossary.md
+++ b/04-guides/genai-basics-glossary.md
@@ -1,3 +1,9 @@
+---
+title: "Generative AI Basics Glossary"
+tags: ["guides", "genai-basics"]
+last_updated: "2026-01-10"
+---
+
 # Generative AI Basics Glossary
 
 ## Intent

--- a/04-guides/genai-terms-explained-v2.md
+++ b/04-guides/genai-terms-explained-v2.md
@@ -1,3 +1,9 @@
+---
+title: "AI Terms Explained (Glossary v2)"
+tags: ["guides", "genai-terms"]
+last_updated: "2026-03-29"
+---
+
 # AI Terms Explained (Glossary v2)
 
 ## Intent

--- a/04-guides/how-to-use-chatgpt.md
+++ b/04-guides/how-to-use-chatgpt.md
@@ -1,3 +1,9 @@
+---
+title: "How to Use ChatGPT"
+tags: ["guides", "use-chatgpt"]
+last_updated: "2026-01-10"
+---
+
 # How to Use ChatGPT
 
 ## Intent

--- a/04-guides/llm-lifecycle-monitoring.md
+++ b/04-guides/llm-lifecycle-monitoring.md
@@ -1,3 +1,9 @@
+---
+title: "LLM Lifecycle Monitoring Guide"
+tags: ["guides", "llm-lifecycle"]
+last_updated: "2026-01-10"
+---
+
 # LLM Lifecycle Monitoring Guide
 
 ## Intent

--- a/04-guides/overview.md
+++ b/04-guides/overview.md
@@ -1,3 +1,9 @@
+---
+title: "Overview"
+tags: ["guides"]
+last_updated: "2026-01-10"
+---
+
 # Guides Overview
 
 ## Gemini Prompting Guide 101

--- a/04-guides/reasoning-vs-classic-llms-de.md
+++ b/04-guides/reasoning-vs-classic-llms-de.md
@@ -1,3 +1,9 @@
+---
+title: "Reasoning vs. Classic LLMs (DE)"
+tags: ["guides", "reasoning-classic"]
+last_updated: "2026-01-10"
+---
+
 # Reasoning-LLMs vs. klassische GPT-Modelle
 
 ## Zweck

--- a/04-guides/reasoning-vs-classic-llms.md
+++ b/04-guides/reasoning-vs-classic-llms.md
@@ -1,3 +1,9 @@
+---
+title: "Reasoning vs. Classic LLMs"
+tags: ["guides", "reasoning-classic"]
+last_updated: "2026-01-10"
+---
+
 # Reasoning LLMs vs. Classic GPT-Style LLMs
 
 ## Intent

--- a/04-guides/top-10-ml-algorithms.md
+++ b/04-guides/top-10-ml-algorithms.md
@@ -1,3 +1,9 @@
+---
+title: "Top 10 Machine Learning Algorithms"
+tags: ["guides", "top-10"]
+last_updated: "2026-01-10"
+---
+
 # Top 10 Machine Learning Algorithms (2025 Field Guide)
 
 ## Intent

--- a/04-guides/vibe-coding-tech-stack.md
+++ b/04-guides/vibe-coding-tech-stack.md
@@ -1,3 +1,9 @@
+---
+title: "Vibe Coding Tech Stack Tutorial"
+tags: ["guides", "vibe-coding"]
+last_updated: "2026-01-31"
+---
+
 # Vibe Coding Tech Stack Tutorial
 
 ## Intent

--- a/05-tools/ai-tool-chaining-oct-2025.md
+++ b/05-tools/ai-tool-chaining-oct-2025.md
@@ -1,3 +1,9 @@
+---
+title: "AI Tool Chaining (Oct 2025)"
+tags: ["tools", "chaining"]
+last_updated: "2026-01-10"
+---
+
 # AI Tool Chaining Playbook (October 2025)
 
 ## Intent

--- a/05-tools/best-ai-apps-2026.md
+++ b/05-tools/best-ai-apps-2026.md
@@ -1,3 +1,9 @@
+---
+title: "Best AI Apps for 2026"
+tags: ["tools", "best-apps"]
+last_updated: "2026-04-08"
+---
+
 # The Best AI Apps for 2026
 
 A curated pyramid of the top AI tools across five categories — from general assistants at the peak to creativity tools at the base — plus a bonus row of automation and workflow tools.

--- a/05-tools/claude-ai-vs-code-vs-cowork.md
+++ b/05-tools/claude-ai-vs-code-vs-cowork.md
@@ -1,3 +1,9 @@
+---
+title: "Claude AI vs Claude Code vs Claude Cowork"
+tags: ["tools", "claude-code"]
+last_updated: "2026-03-08"
+---
+
 # Claude Ecosystem: AI vs Code vs Cowork
 
 ## Intent

--- a/05-tools/claude-code-certification-guide.md
+++ b/05-tools/claude-code-certification-guide.md
@@ -1,3 +1,9 @@
+---
+title: "Claude Code Certification Guide"
+tags: ["tools", "claude-code"]
+last_updated: "2026-03-15"
+---
+
 # Claude Code Certification Guide (Claude Certified Architect Foundations)
 
 ## Intent

--- a/05-tools/claude-code-cheatsheet-tutorial.md
+++ b/05-tools/claude-code-cheatsheet-tutorial.md
@@ -1,3 +1,9 @@
+---
+title: "Claude Code Cheatsheet Tutorial"
+tags: ["tools", "claude-code"]
+last_updated: "2026-04-22"
+---
+
 # Claude Code Cheatsheet Transcription and Tool Tutorial
 
 ## Claude Code Cheatsheet (Text Transcription)

--- a/05-tools/claude-code-cheatsheet-v2.md
+++ b/05-tools/claude-code-cheatsheet-v2.md
@@ -1,3 +1,9 @@
+---
+title: "Claude Code Cheat Sheet v2.81"
+tags: ["tools", "claude-code"]
+last_updated: "2026-04-22"
+---
+
 # Claude Code Cheat Sheet v2.81
 
 > **Version:** Claude Code v2.81 — as of **March 24, 2026**

--- a/05-tools/claude-code-notebooklm-integration-tutorial.md
+++ b/05-tools/claude-code-notebooklm-integration-tutorial.md
@@ -1,3 +1,9 @@
+---
+title: "Claude Code + NotebookLM Integration Tutorial"
+tags: ["tools", "claude-code"]
+last_updated: "2026-03-05"
+---
+
 # Claude Code + NotebookLM Integration Tutorial
 
 ## Intent

--- a/05-tools/claude-code-project-structure-tutorial.md
+++ b/05-tools/claude-code-project-structure-tutorial.md
@@ -1,3 +1,9 @@
+---
+title: "Claude Code Project Structure Tutorial"
+tags: ["tools", "claude-code"]
+last_updated: "2026-04-22"
+---
+
 # Claude Code Project Structure Tutorial
 
 You won't need any other project structure for Claude Code. Just this one. This definitive guide covers where skills go, how to organize hooks and MCP servers, and explains the 6 extension types alongside memory file workflows.

--- a/05-tools/claude-code-tool-guide.md
+++ b/05-tools/claude-code-tool-guide.md
@@ -1,3 +1,9 @@
+---
+title: "Claude Code Tool Guide"
+tags: ["tools", "claude-code"]
+last_updated: "2026-01-10"
+---
+
 # Claude Code Tool Guide
 
 ## Intent

--- a/05-tools/coding-ai-agent-selection-tutorial.md
+++ b/05-tools/coding-ai-agent-selection-tutorial.md
@@ -1,3 +1,9 @@
+---
+title: "Right Selection of a Coding AI Agent (2026)"
+tags: ["tools", "coding-agent"]
+last_updated: "2026-03-03"
+---
+
 # Right Selection of a Coding AI Agent (2026 Tutorial)
 
 ## Intent

--- a/05-tools/copilot-prompt-template.md
+++ b/05-tools/copilot-prompt-template.md
@@ -1,3 +1,9 @@
+---
+title: "Microsoft Copilot Prompt Template"
+tags: ["tools", "copilot-template"]
+last_updated: "2026-04-22"
+---
+
 <img src="../assets/microsoft/microsoft_copilot.jpg" alt="Copilot Copilot" width="80%">
 
 # Microsoft Copilot Prompt Template

--- a/05-tools/cowork-tool-selection-tutorial.md
+++ b/05-tools/cowork-tool-selection-tutorial.md
@@ -1,3 +1,9 @@
+---
+title: "Cowork Tool Selection Tutorial"
+tags: ["tools", "cowork-selection"]
+last_updated: "2026-03-22"
+---
+
 # Right Selection of a Cowork AI Tool (2026 Tutorial)
 
 ## Intent

--- a/05-tools/elevenlabs-guide.md
+++ b/05-tools/elevenlabs-guide.md
@@ -1,3 +1,9 @@
+---
+title: "ElevenLabs Guide"
+tags: ["tools", "elevenlabs"]
+last_updated: "2026-01-14"
+---
+
 # ElevenLabs Guide
 
 ## Intent

--- a/05-tools/gamma-guide.md
+++ b/05-tools/gamma-guide.md
@@ -1,3 +1,9 @@
+---
+title: "Gamma Guide"
+tags: ["tools", "gamma"]
+last_updated: "2026-01-14"
+---
+
 # Gamma Guide
 
 ## Intent

--- a/05-tools/github-copilot-coding-agent-mcp-tutorial.md
+++ b/05-tools/github-copilot-coding-agent-mcp-tutorial.md
@@ -1,3 +1,9 @@
+---
+title: "GitHub Copilot Coding Agent MCP Tutorial"
+tags: ["tools", "github-copilot"]
+last_updated: "2026-01-24"
+---
+
 <img src="../assets/microsoft/github-copilot.png" alt="GitHub Copilot" width="80%">
 
 # Intent

--- a/05-tools/github-copilot-custom-instructions-tutorial.md
+++ b/05-tools/github-copilot-custom-instructions-tutorial.md
@@ -1,3 +1,9 @@
+---
+title: "GitHub Copilot Custom Instructions Tutorial"
+tags: ["tools", "github-copilot"]
+last_updated: "2026-01-10"
+---
+
 <img src="../assets/microsoft/github-copilot.png" alt="GitHub Copilot" width="80%">
 
 # Intent

--- a/05-tools/google-cloud-platform-agents.md
+++ b/05-tools/google-cloud-platform-agents.md
@@ -1,3 +1,9 @@
+---
+title: "Google Cloud ADK Quickstart"
+tags: ["tools", "google-cloud"]
+last_updated: "2026-01-10"
+---
+
 <img src="../assets/google/google_cloud_platform.png" alt="Google Cloud Platform" width="80%">
 
 # Google Cloud Agent Development Kit (ADK) Quickstart

--- a/05-tools/heygen-guide.md
+++ b/05-tools/heygen-guide.md
@@ -1,3 +1,9 @@
+---
+title: "HeyGen Guide"
+tags: ["tools", "heygen"]
+last_updated: "2026-01-14"
+---
+
 # HeyGen Guide
 
 ## Intent

--- a/05-tools/langchain-deep-agents.md
+++ b/05-tools/langchain-deep-agents.md
@@ -1,3 +1,9 @@
+---
+title: "LangChain Deep Agents Playbook"
+tags: ["tools", "langchain-agents"]
+last_updated: "2026-01-10"
+---
+
 <img src="../assets/langchain/langchain_deep_agent.png" alt="Langchain Deep Agent" width="80%">
 
 # LangChain Deep Agents Playbook

--- a/05-tools/llm-on-phone-deployment-tutorial.md
+++ b/05-tools/llm-on-phone-deployment-tutorial.md
@@ -1,3 +1,9 @@
+---
+title: "Unsloth Phone Deployment Tutorial"
+tags: ["tools", "llm-on"]
+last_updated: "2026-01-10"
+---
+
 # Unsloth Phone Deployment Tutorial (iOS + Android)
 
 ## Intent

--- a/05-tools/lovable-vibe-coding-tutorial.md
+++ b/05-tools/lovable-vibe-coding-tutorial.md
@@ -1,3 +1,9 @@
+---
+title: "Lovable Vibe Coding Tutorial"
+tags: ["tools", "lovable-vibe"]
+last_updated: "2026-02-12"
+---
+
 <img src="../assets/lovable/lovable.webp" alt="Lovable" width="80%">
 
 # Lovable Vibe Coding Tutorial: Architecture-First Pairing

--- a/05-tools/lyra-3-gemini.md
+++ b/05-tools/lyra-3-gemini.md
@@ -1,3 +1,9 @@
+---
+title: "Lyria 3 in Gemini"
+tags: ["tools", "lyra-gemini"]
+last_updated: "2026-02-25"
+---
+
 # Lyria 3 in Gemini: 6 Prompting Tips Tutorial
 
 ## Intent

--- a/05-tools/microsoft-365-copilot-prompting-guide.md
+++ b/05-tools/microsoft-365-copilot-prompting-guide.md
@@ -1,3 +1,9 @@
+---
+title: "Microsoft 365 Copilot Prompting Guide"
+tags: ["tools", "microsoft-365"]
+last_updated: "2026-01-10"
+---
+
 # Microsoft 365 Copilot Prompting Guide
 
 ## Intent

--- a/05-tools/microsoft-agent-framework.md
+++ b/05-tools/microsoft-agent-framework.md
@@ -1,3 +1,9 @@
+---
+title: "Microsoft Agent Framework Quickstart"
+tags: ["tools", "microsoft-agent"]
+last_updated: "2026-01-10"
+---
+
 <img src="../assets/microsoft/microsoft_agent_framework.png" alt="Microsoft Agent Framework" width="80%">
 
 # Microsoft Agent Framework Quickstart

--- a/05-tools/microsoft-copilot-agents.md
+++ b/05-tools/microsoft-copilot-agents.md
@@ -1,3 +1,9 @@
+---
+title: "Microsoft Copilot Agents"
+tags: ["tools", "microsoft-copilot"]
+last_updated: "2026-01-10"
+---
+
 <img src="../assets/microsoft/copilot_agent_builder.png" alt="Copilot Agent Builder" width="80%">
 
 # Microsoft Copilot Agents Guide

--- a/05-tools/microsoft-copilot-researcher-agent.md
+++ b/05-tools/microsoft-copilot-researcher-agent.md
@@ -1,3 +1,9 @@
+---
+title: "Microsoft Copilot Researcher Agent"
+tags: ["tools", "microsoft-copilot"]
+last_updated: "2026-04-22"
+---
+
 <img src="../assets/microsoft/microsoft_researcher_agent.png" alt="Microsoft Copilot Researcher Agent" width="80%">
 
 # Microsoft Copilot Researcher Agent Blueprint

--- a/05-tools/microsoft-facilitator-agent.md
+++ b/05-tools/microsoft-facilitator-agent.md
@@ -1,3 +1,9 @@
+---
+title: "Microsoft Facilitator Agent"
+tags: ["tools", "microsoft-facilitator"]
+last_updated: "2026-01-10"
+---
+
 <img src="../assets/microsoft/microsoft_facilitator_agent.png" alt="Microsoft Facilitator Agent" width="80%">
 
 # Microsoft Facilitator Agent Blueprint

--- a/05-tools/microsoft-sharepoint-knowledge-agent.md
+++ b/05-tools/microsoft-sharepoint-knowledge-agent.md
@@ -1,3 +1,9 @@
+---
+title: "Microsoft SharePoint Knowledge Agent"
+tags: ["tools", "microsoft-sharepoint"]
+last_updated: "2026-01-10"
+---
+
 <img src="../assets/microsoft/microsoft_sharepoint_knowledge_agent.jpg" alt="Microsoft Sharepoint Knowledge Agent" width="80%">
 
 # Microsoft SharePoint Knowledge Agent Blueprint

--- a/05-tools/n8n-research-workflow-tutorial.md
+++ b/05-tools/n8n-research-workflow-tutorial.md
@@ -1,3 +1,9 @@
+---
+title: "n8n Vibe Research Workflow Tutorial"
+tags: ["tools", "n8n-research"]
+last_updated: "2026-01-10"
+---
+
 # n8n Vibe Research Workflow Tutorial
 
 ## Intent

--- a/05-tools/n8n-vs-langgraph.md
+++ b/05-tools/n8n-vs-langgraph.md
@@ -1,3 +1,9 @@
+---
+title: "n8n vs LangGraph Comparison"
+tags: ["tools", "n8n-langgraph"]
+last_updated: "2026-01-10"
+---
+
 # n8n vs LangGraph: Tool Comparison
 
 ## Intent

--- a/05-tools/nanogpt-tool-guide.md
+++ b/05-tools/nanogpt-tool-guide.md
@@ -1,3 +1,9 @@
+---
+title: "nanoGPT + nanochat Tool Guide"
+tags: ["tools", "nanogpt"]
+last_updated: "2026-01-10"
+---
+
 # nanoGPT + nanochat Tool Guide
 
 ## Intent

--- a/05-tools/napkin-guide.md
+++ b/05-tools/napkin-guide.md
@@ -1,3 +1,9 @@
+---
+title: "Napkin Guide"
+tags: ["tools", "napkin"]
+last_updated: "2026-01-14"
+---
+
 # Napkin Guide
 
 ## Intent

--- a/05-tools/notebooklm-2026-tool-tutorial.md
+++ b/05-tools/notebooklm-2026-tool-tutorial.md
@@ -1,3 +1,9 @@
+---
+title: "NotebookLM 2026 Tool Tutorial"
+tags: ["tools", "notebooklm"]
+last_updated: "2026-04-22"
+---
+
 # NotebookLM 2026 Tool Tutorial: Curate -> Learn -> Act
 
 ## Intent

--- a/05-tools/notebooklm-audio-overviews-blueprint.md
+++ b/05-tools/notebooklm-audio-overviews-blueprint.md
@@ -1,3 +1,9 @@
+---
+title: "NotebookLM Audio Overviews"
+tags: ["tools", "notebooklm-audio"]
+last_updated: "2026-01-10"
+---
+
 <img src="../assets/google/google_notebooklm_audio_overview.jpg" alt="Google NotebookLM Audio Overview" width="80%">
 
 # NotebookLM Audio Overviews Blueprint

--- a/05-tools/notebooklm-prompting-blueprints.md
+++ b/05-tools/notebooklm-prompting-blueprints.md
@@ -1,3 +1,9 @@
+---
+title: "NotebookLM Prompting Blueprints"
+tags: ["tools", "notebooklm-blueprints"]
+last_updated: "2026-01-11"
+---
+
 # NotebookLM Prompting Blueprints
 
 ## 1. The "5 Essential Questions"

--- a/05-tools/openai-gpt-5-prompt-optimizer.md
+++ b/05-tools/openai-gpt-5-prompt-optimizer.md
@@ -1,3 +1,9 @@
+---
+title: "OpenAI GPT-5 Prompt Optimizer"
+tags: ["tools", "openai-gpt"]
+last_updated: "2026-01-10"
+---
+
 <img src="../assets/openai/openai_prompt_optimizer.gif" alt="OpenAI Prompt Optimizer" width="80%">
 
 # GPT-5 Prompt Optimizer Tutorial: From Baseline Prompt to Production Ready Instructions

--- a/05-tools/perplexity-comet.md
+++ b/05-tools/perplexity-comet.md
@@ -1,3 +1,9 @@
+---
+title: "Perplexity Comet"
+tags: ["tools", "perplexity-comet"]
+last_updated: "2026-01-10"
+---
+
 <img src="../assets/perplexity/perplexity_comet.png" alt="Perplexity Comet" width="80%">
 
 # Perplexity Comet Tutorial: Multi‑Tab Synthesis for LinkedIn Article

--- a/05-tools/spec-driven-development-ai-tutorial.md
+++ b/05-tools/spec-driven-development-ai-tutorial.md
@@ -1,3 +1,9 @@
+---
+title: "Spec-Driven Development with AI Tools"
+tags: ["tools", "spec-driven"]
+last_updated: "2026-03-25"
+---
+
 # Spec-Driven Development with AI-Native Tools (2026 Tutorial)
 
 ## Intent

--- a/05-tools/spec-driven-development-tutorial.md
+++ b/05-tools/spec-driven-development-tutorial.md
@@ -1,3 +1,9 @@
+---
+title: "Spec-Driven Development Tutorial"
+tags: ["tools", "spec-driven"]
+last_updated: "2026-03-27"
+---
+
 # Spec-Driven Development Tutorial
 
 ## Intent

--- a/05-tools/suno-guide.md
+++ b/05-tools/suno-guide.md
@@ -1,3 +1,9 @@
+---
+title: "Suno Guide"
+tags: ["tools", "suno"]
+last_updated: "2026-01-14"
+---
+
 # Suno Guide
 
 ## Intent

--- a/05-tools/vibe-kanban-tool-tutorial.md
+++ b/05-tools/vibe-kanban-tool-tutorial.md
@@ -1,3 +1,9 @@
+---
+title: "Vibe Kanban Tool Tutorial"
+tags: ["tools", "vibe-kanban"]
+last_updated: "2026-01-10"
+---
+
 # Vibe Kanban Tutorial: Parallel AI Coding Board
 ![Vibe Kanban dashboard](../assets/other/vibe-kanban.jpg)
 

--- a/07-use-cases-and-research/ai-use-case-identification.md
+++ b/07-use-cases-and-research/ai-use-case-identification.md
@@ -1,3 +1,9 @@
+---
+title: "AI Use Case Identification"
+tags: ["research", "use-case"]
+last_updated: "2026-01-10"
+---
+
 # AI Use Case Identification
 
 **Intent:** Help product and transformation teams identify high-value AI opportunities under real-world business constraints.

--- a/07-use-cases-and-research/ai-video-camera-movements-prompt-library.md
+++ b/07-use-cases-and-research/ai-video-camera-movements-prompt-library.md
@@ -1,3 +1,9 @@
+---
+title: "AI Video Camera Movements Prompt Library"
+tags: ["research", "video-camera"]
+last_updated: "2026-02-25"
+---
+
 # AI Video Camera Movements Prompt Library (42 Moves)
 
 ## Intent

--- a/07-use-cases-and-research/deep-research.md
+++ b/07-use-cases-and-research/deep-research.md
@@ -1,3 +1,9 @@
+---
+title: "Deep Research Tools Playbook"
+tags: ["research"]
+last_updated: "2026-01-10"
+---
+
 # Deep Research Tutorial
 
 ## Intent

--- a/07-use-cases-and-research/langchain-research-agent.md
+++ b/07-use-cases-and-research/langchain-research-agent.md
@@ -1,3 +1,9 @@
+---
+title: "LangChain Research Agent Tutorial"
+tags: ["research", "langchain-research"]
+last_updated: "2026-01-10"
+---
+
 <img src="../assets/langchain/langchain_deep_agent.png" alt="Langchain Deep Agent" width="80%">
 
 # LangChain Research Agent Tutorial

--- a/07-use-cases-and-research/microsoft-adoption-scenario-library.md
+++ b/07-use-cases-and-research/microsoft-adoption-scenario-library.md
@@ -1,3 +1,9 @@
+---
+title: "Microsoft Adoption Scenario Library"
+tags: ["research", "microsoft-adoption"]
+last_updated: "2026-01-10"
+---
+
 <img src="../assets/microsoft/microsoft_scenario_library.png" alt="Microsoft Scenario Library" width="80%">
 
 # Microsoft Adoption Scenario Library Prompts

--- a/07-use-cases-and-research/program-delivery-manager-copilot-playbook.md
+++ b/07-use-cases-and-research/program-delivery-manager-copilot-playbook.md
@@ -1,3 +1,9 @@
+---
+title: "Program Delivery Manager Copilot Playbook"
+tags: ["research", "program-delivery"]
+last_updated: "2026-01-10"
+---
+
 <img src="../assets/microsoft/microsoft_copilot_program_delivery_manager.png" alt="Copilot Program Delivery Manager" width="80%">
 
 # Program Delivery Manager Copilot Playbook

--- a/07-use-cases-and-research/requirements-engineering-dataset-experiments.md
+++ b/07-use-cases-and-research/requirements-engineering-dataset-experiments.md
@@ -1,3 +1,9 @@
+---
+title: "Requirements Engineering Dataset Experiments"
+tags: ["research", "requirements-engineering"]
+last_updated: "2026-01-10"
+---
+
 # Experiment with AI on Requirements Engineering Datasets
 
 ## Intent

--- a/07-use-cases-and-research/summarization-tutorial.md
+++ b/07-use-cases-and-research/summarization-tutorial.md
@@ -1,3 +1,9 @@
+---
+title: "Summarization Playbook"
+tags: ["research", "summarization"]
+last_updated: "2026-01-10"
+---
+
 # Summarization Playbook
 
 ## Intent

--- a/07-use-cases-and-research/vibe-research.md
+++ b/07-use-cases-and-research/vibe-research.md
@@ -1,3 +1,9 @@
+---
+title: "Vibe Research Playbook"
+tags: ["research", "vibe-research"]
+last_updated: "2026-01-10"
+---
+
 # Vibe Research Playbook
 
 ## Intent

--- a/agents.md
+++ b/agents.md
@@ -9,6 +9,7 @@
 - Keep contributions **scoped, reversible, and copy-ready**.
 - Run `mkdocs build` (docs) and relevant `promptfoo test` configs before opening a PR.
 - Update `CHANGELOG.md` under **Unreleased** and document new pages in `mkdocs.yml` when required.
+- **Every new content file needs YAML front-matter.** Run `python3 scripts/check-frontmatter.py` before opening a PR.
 
 ---
 
@@ -60,6 +61,36 @@
 - Start each new resource with an **Intent** or **Use when** section.
 - Include an **OUTPUT FORMAT** section (JSON or Markdown) when structure matters.
 - Reference related patterns, prompt packs, and use cases to keep navigation cohesive.
+
+### Front-matter (required for all new content files)
+Every new `.md` file in `02-ai-agents/`, `03-prompts-and-patterns/`, `04-guides/`, `05-tools/`, and `07-use-cases-and-research/` must open with a YAML front-matter block.
+
+**Tier A — `03-prompts-and-patterns/`** (full schema):
+```yaml
+---
+title: "Pattern: Role + Constraints + Output Format"
+intent: "One sentence describing what this pattern achieves"
+model_tested: ["GPT-5", "Claude Sonnet 4.6"]
+tags: ["patterns", "structure"]
+last_updated: 2026-04-22
+---
+```
+
+**Tier B — all other content directories** (operational schema):
+```yaml
+---
+title: "MCP Guide"
+tags: ["agents", "mcp"]
+last_updated: 2026-04-22
+---
+```
+
+Rules:
+- `title`: use the exact nav label from `mkdocs.yml`, or the first `# Heading` if not yet registered.
+- `tags`: first tag is always the directory category (`agents`, `patterns`, `guides`, `tools`, `research`); add 1–2 specific keywords after it.
+- `last_updated`: ISO date (`YYYY-MM-DD`) of the commit that creates or significantly updates the file.
+- `model_tested`: required for Tier A only; list every model you tested the prompt against.
+- Run `python3 scripts/check-frontmatter.py` to verify before opening a PR. To generate stubs for new files in bulk, use `python3 scripts/add-frontmatter.py --dry-run` first.
 
 ### Patterns & prompts specifics
 - Provide guidance on variables/placeholders and guardrails.
@@ -124,6 +155,8 @@ If a command fails, capture the error, suggest a minimal fix, and avoid broad de
 - [ ] Relevant `promptfoo test` suites pass, or failures are explained with follow-ups created.
 - [ ] `CHANGELOG.md` updated under **Unreleased**.
 - [ ] Labels added (`area:*`, `type:*`).
+- [ ] All new content files have YAML front-matter (`python3 scripts/check-frontmatter.py` exits 0).
+- [ ] Internal links use explicit relative paths (`./` or `../`), not bare filenames.
 
 > When in doubt, pause and ask: Who is the audience? Should this be a new page or an update? Are there tone/length constraints?
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,9 @@ nav:
     - Summarization Playbook: 07-use-cases-and-research/summarization-tutorial.md
     - AI Video Camera Movements Prompt Library: 07-use-cases-and-research/ai-video-camera-movements-prompt-library.md
   - External Sources: external-sources.md
+plugins:
+  - search
+  - tags
 markdown_extensions:
   - admonition
   - toc:

--- a/scripts/add-frontmatter.py
+++ b/scripts/add-frontmatter.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""
+Generate YAML front-matter stubs for content files that lack them.
+
+Tier A (03-prompts-and-patterns): title, intent, model_tested, tags, last_updated
+Tier B (02-ai-agents, 04-guides, 05-tools, 07-use-cases-and-research): title, tags, last_updated
+Tier C (everything else): skipped
+
+Run from the repo root:
+    python3 scripts/add-frontmatter.py [--dry-run]
+"""
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+
+TIER_A = {"03-prompts-and-patterns"}
+TIER_B = {"02-ai-agents", "04-guides", "05-tools", "07-use-cases-and-research"}
+
+DIR_TAGS = {
+    "02-ai-agents": "agents",
+    "03-prompts-and-patterns": "patterns",
+    "04-guides": "guides",
+    "05-tools": "tools",
+    "07-use-cases-and-research": "research",
+}
+
+STOP_WORDS = {
+    "ai", "tool", "the", "and", "for", "with", "how", "to", "of", "a", "an",
+    "guide", "tutorial", "overview", "playbook", "blueprint", "prompt", "prompting",
+    "2025", "2026", "jan", "feb", "mar", "apr", "may", "jun",
+    "jul", "aug", "sep", "oct", "nov", "dec",
+    "vs", "via", "deep", "intro", "introduction", "using",
+}
+
+VERSION_RE = re.compile(r"^v\d+(\.\d+)*$")
+YEAR_RE = re.compile(r"^\d{4}$")
+
+
+def get_nav_titles() -> dict[str, str]:
+    """Parse mkdocs.yml and return {relative_path: nav_title}."""
+    import yaml  # guarded import — only needed here
+
+    with open(REPO_ROOT / "mkdocs.yml", encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    titles: dict[str, str] = {}
+
+    def walk(nav):
+        for item in nav:
+            if isinstance(item, dict):
+                for key, value in item.items():
+                    if isinstance(value, str):
+                        titles[value] = key
+                    elif isinstance(value, list):
+                        walk(value)
+
+    walk(config.get("nav", []))
+    return titles
+
+
+def git_date(path: Path) -> str:
+    result = subprocess.run(
+        ["git", "log", "-1", "--format=%as", "--", str(path)],
+        capture_output=True, text=True, cwd=REPO_ROOT,
+    )
+    return result.stdout.strip() or "2025-01-01"
+
+
+def first_heading(content: str) -> str | None:
+    for line in content.splitlines():
+        if line.startswith("# "):
+            return line[2:].strip()
+    return None
+
+
+def extract_intent(content: str) -> str:
+    """Pull first non-empty line(s) from an ## Intent section, if present."""
+    lines = content.splitlines()
+    capturing = False
+    collected: list[str] = []
+
+    for line in lines:
+        if re.match(r"^##\s+Intent", line, re.IGNORECASE):
+            capturing = True
+            continue
+        if capturing:
+            if line.startswith("#"):
+                break
+            stripped = line.strip()
+            if stripped and not stripped.startswith("-") or (stripped.startswith("-") and not collected):
+                # take first prose sentence or first bullet
+                collected.append(stripped.lstrip("- ").strip())
+            if collected:
+                break  # one sentence is enough
+
+    intent = " ".join(collected)[:200]
+    # strip trailing incomplete sentence punctuation
+    return intent.rstrip(",;")
+
+
+def infer_keyword(filename_stem: str) -> str | None:
+    """Return the most informative 1-2 word keyword from a filename stem."""
+    parts = [p for p in filename_stem.split("-") if p]
+    # drop dates, versions, stop words
+    clean = [
+        p for p in parts
+        if p.lower() not in STOP_WORDS
+        and not VERSION_RE.match(p)
+        and not YEAR_RE.match(p)
+        and len(p) > 1
+    ]
+    if not clean:
+        return None
+    # try joining first two words if both survive the filter
+    if len(clean) >= 2:
+        return f"{clean[0]}-{clean[1]}"
+    return clean[0]
+
+
+def format_frontmatter(fields: dict) -> str:
+    lines = ["---"]
+    for key, value in fields.items():
+        if isinstance(value, str):
+            escaped = value.replace('"', '\\"')
+            lines.append(f'{key}: "{escaped}"')
+        elif isinstance(value, list):
+            items = ", ".join(f'"{v}"' for v in value)
+            lines.append(f"{key}: [{items}]")
+        else:
+            lines.append(f"{key}: {value}")
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def process_file(path: Path, nav_titles: dict, tier: str, dry_run: bool) -> str:
+    """
+    Returns: "skipped" | "already" | "written"
+    """
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+
+    if content.lstrip().startswith("---"):
+        return "already"
+
+    rel = str(path.relative_to(REPO_ROOT))
+    dir_name = path.parent.name
+    stem = path.stem
+
+    title = (
+        nav_titles.get(rel)
+        or first_heading(content)
+        or stem.replace("-", " ").title()
+    )
+
+    primary_tag = DIR_TAGS.get(dir_name, dir_name)
+    keyword = infer_keyword(stem)
+    tags = [primary_tag] + ([keyword] if keyword and keyword != primary_tag else [])
+
+    date = git_date(path)
+
+    if tier == "A":
+        intent = extract_intent(content)
+        fields = {
+            "title": title,
+            "intent": intent,
+            "model_tested": [],
+            "tags": tags,
+            "last_updated": date,
+        }
+    else:
+        fields = {
+            "title": title,
+            "tags": tags,
+            "last_updated": date,
+        }
+
+    fm = format_frontmatter(fields)
+    new_content = fm + "\n\n" + content
+
+    if not dry_run:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(new_content)
+
+    return "written"
+
+
+def main():
+    dry_run = "--dry-run" in sys.argv
+
+    if dry_run:
+        print("DRY RUN — no files will be modified\n")
+
+    nav_titles = get_nav_titles()
+
+    counts = {"written": 0, "already": 0, "skipped": 0}
+
+    for dir_name, tier in [(d, "A") for d in TIER_A] + [(d, "B") for d in TIER_B]:
+        dir_path = REPO_ROOT / dir_name
+        if not dir_path.exists():
+            continue
+        for md_file in sorted(dir_path.glob("*.md")):
+            result = process_file(md_file, nav_titles, tier, dry_run)
+            rel = md_file.relative_to(REPO_ROOT)
+            if result == "written":
+                print(f"  ✓  {rel}")
+            elif result == "already":
+                print(f"  ↷  {rel}  (front-matter exists)")
+            counts[result] += 1
+
+    verb = "would be" if dry_run else "were"
+    print(
+        f"\nDone: {counts['written']} files {verb} updated, "
+        f"{counts['already']} already had front-matter."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-frontmatter.py
+++ b/scripts/check-frontmatter.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+Lint script: verify that all content markdown files have YAML front-matter.
+
+Exits 0 if all files pass, 1 if any violations are found.
+
+Usage:
+    python3 scripts/check-frontmatter.py
+
+Add to CI or as a pre-commit hook to prevent regression.
+"""
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+
+CONTENT_DIRS = {
+    "02-ai-agents",
+    "03-prompts-and-patterns",
+    "04-guides",
+    "05-tools",
+    "07-use-cases-and-research",
+}
+
+
+def has_frontmatter(path: Path) -> bool:
+    with open(path, encoding="utf-8") as f:
+        first = f.read(4)
+    return first.startswith("---")
+
+
+def main():
+    violations: list[str] = []
+
+    for dir_name in sorted(CONTENT_DIRS):
+        dir_path = REPO_ROOT / dir_name
+        if not dir_path.exists():
+            continue
+        for md_file in sorted(dir_path.glob("*.md")):
+            if not has_frontmatter(md_file):
+                violations.append(str(md_file.relative_to(REPO_ROOT)))
+
+    if violations:
+        print(f"FAIL: {len(violations)} file(s) missing front-matter:\n")
+        for v in violations:
+            print(f"  {v}")
+        print(
+            "\nRun  python3 scripts/add-frontmatter.py  to generate stubs, "
+            "then review and fill in any blank fields."
+        )
+        sys.exit(1)
+    else:
+        print(f"OK: all content files have front-matter.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Three related quality fixes identified during a repository review:

- **30 broken internal markdown links** across 9 files — all caused by bare filenames instead of explicit relative paths (`mcp-guide.md` → `./mcp-guide.md`). All target files existed; only the path format was wrong.
- **Missing YAML front-matter** on 87 of 88 content files — stubs generated with titles sourced from `mkdocs.yml` nav, tags inferred from directory and filename, and `last_updated` from git log. MkDocs Material tags plugin enabled.
- **No contributor guidance** on either convention — both now documented in `agents.md` with copy-paste templates, field rules, and lint commands.

## Changes

### Broken links (`fix: resolve 30 broken internal markdown links`)
- Added `./` prefix to same-directory links and `../` for cross-directory links in 9 files
- Affected files: `claude-code-cheatsheet-v2.md`, `ultimate-2026-ai-software-implementation-guide.md`, `google-5-day-ai-agents-course.md`, `claude-code-project-structure-tutorial.md`, `notebooklm-2026-tool-tutorial.md`, `microsoft-copilot-researcher-agent.md`, `copilot-prompt-template.md`, `claude-code-cheatsheet-tutorial.md`, `self-evolving-agents-google-adk.md`

### Front-matter (`feat: add YAML front-matter to all content files`)
- Added front-matter stubs to 87 files across `02-ai-agents/`, `03-prompts-and-patterns/`, `04-guides/`, `05-tools/`, `07-use-cases-and-research/`
- **Tier A** (`03-prompts-and-patterns/`): `title`, `intent`, `model_tested`, `tags`, `last_updated`
- **Tier B** (all other content dirs): `title`, `tags`, `last_updated`
- Enabled MkDocs Material `tags` plugin in `mkdocs.yml`
- Added `scripts/add-frontmatter.py` — regeneration tool with `--dry-run` support
- Added `scripts/check-frontmatter.py` — lint script (exits 1 on violations); ready for CI or pre-commit

### Contributor guidelines (`docs: add front-matter and link conventions to agents.md`)
- New "Front-matter (required for all new content files)" subsection in section 3 with copy-paste templates for both tiers
- Two new PR checklist items: front-matter check and explicit relative links check
- TL;DR bullet pointing to `check-frontmatter.py`

## Test plan

- [ ] `python3 scripts/check-frontmatter.py` exits 0
- [ ] `mkdocs build` succeeds
- [ ] Spot-check a few files to confirm front-matter and links look correct
- [ ] Review `model_tested: []` fields in `03-prompts-and-patterns/` — fill in actual models tested

## Notes

`model_tested` is left as `[]` on all Tier A pattern files and needs manual review — the script cannot reliably infer which models were tested from file content alone.

https://claude.ai/code/session_01LQw1iMrfZ2VbXqJouBsF1H

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQw1iMrfZ2VbXqJouBsF1H)_