### PR TITLE
docs: improve PDF references and consolidate skills nav

### DIFF
--- a/02-ai-agents/anatomy-of-a-skill.md
+++ b/02-ai-agents/anatomy-of-a-skill.md
@@ -59,6 +59,35 @@ description: Comprehensive PDF toolkit for extracting text and tables,
 
 **Write the description as a usage hint, not a feature list.** Claude matches user intent against descriptions. "Use this skill when the user needs to read, create, merge, split, or fill PDF documents" outperforms "PDF operations toolkit."
 
+### Optional fields
+
+| Field | Constraint | Purpose |
+|---|---|---|
+| `license` | string e.g. `MIT`, `Apache-2.0` | Licence declaration for open-source skills |
+| `compatibility` | 1–500 chars | Environment requirements: platform, system packages, network access |
+| `allowed-tools` | space-separated tool specs | Restrict which tools the skill may invoke |
+| `metadata` | key-value object | Custom fields: `author`, `version`, `mcp-server`, `category`, `tags` |
+
+Full frontmatter with all optional fields:
+
+```yaml
+---
+name: my-skill
+description: What it does. Use when user asks to [specific phrases].
+license: MIT
+compatibility: Requires Python 3.11+. Network access to api.example.com needed.
+allowed-tools: "Bash(python:*) WebFetch"
+metadata:
+  author: YourCompany
+  version: 1.0.0
+  mcp-server: my-service
+  category: productivity
+  tags: [automation, reporting]
+---
+```
+
+**Security:** Never include XML angle brackets (`<` or `>`) in frontmatter — it is injected directly into Claude's system prompt. Skills named with a `claude` or `anthropic` prefix are reserved and will be rejected on upload.
+
 ### Markdown Body
 
 Everything after the frontmatter is the instruction document — plain GitHub-flavoured Markdown. Use headings, bullet lists, fenced code blocks, and tables exactly as you would in any documentation file.
@@ -319,6 +348,70 @@ Skills execute code and can direct Claude to invoke tools. Before activating a s
 4. Only install skills from sources you control or have audited.
 
 The official [anthropics/skills](https://github.com/anthropics/skills) repository is provided for demonstration and educational purposes. Test behaviour in your own environment before using skills in production.
+
+---
+
+## Troubleshooting
+
+### Skill won't upload
+
+**"Could not find SKILL.md"** — The file is not named exactly `SKILL.md`. No variations (`skill.md`, `SKILL.MD`) are accepted. Rename and re-zip.
+
+**"Invalid frontmatter"** — YAML formatting error. Common mistakes:
+
+```yaml
+# Wrong — missing --- delimiters
+name: my-skill
+description: Does things
+
+# Wrong — unclosed quote
+description: "Does things
+
+# Correct
+---
+name: my-skill
+description: Does things.
+---
+```
+
+**"Invalid skill name"** — `name` contains spaces or uppercase letters. Use only lowercase letters, numbers, and hyphens: `my-skill-name`.
+
+### Skill does not trigger
+
+Claude reads the `description` to route requests. If the skill never loads automatically:
+
+- The description is too generic — "Helps with projects" matches nothing specific.
+- Trigger phrases are absent — add phrases users would actually type.
+- Domain-specific terms are missing — if users say "OCR" or "PDF form", those exact words must appear in the description.
+
+**Debug:** Ask Claude `"When would you use the [skill-name] skill?"` — it will quote the description back verbatim. Adjust based on what is missing or vague.
+
+### Skill triggers too often
+
+Narrow scope and add negative triggers:
+
+```
+description: Advanced PDF analysis for legal contracts. Use for clause
+extraction and redline comparison. Do NOT use for simple PDF reading
+(use the pdf skill instead).
+```
+
+### MCP connection issues
+
+If the skill loads but MCP calls fail, work through this checklist in order:
+
+1. Verify the MCP server shows "Connected" in Claude.ai Settings > Extensions.
+2. Confirm the API key is valid and unexpired; refresh OAuth tokens if applicable.
+3. Test the MCP independently — ask Claude to call the MCP tool directly without the skill active. If this fails, the issue is in the MCP configuration, not the skill.
+4. Confirm that tool names in the skill match the MCP server's actual tool names exactly (names are case-sensitive).
+
+### Large context / slow responses
+
+Symptoms: noticeably slow responses or degraded output quality.
+
+- Keep `SKILL.md` under 5 000 tokens. Move deep reference content to `references/` sibling files and link to them.
+- If you have more than 20–50 skills enabled simultaneously, consider selective enablement or grouping related skills into packs.
+- Check that the skill uses Level 3 correctly — the body should reference sibling files rather than inlining all content.
 
 ---
 

--- a/02-ai-agents/anatomy-of-a-skill.md
+++ b/02-ai-agents/anatomy-of-a-skill.md
@@ -330,3 +330,5 @@ The official [anthropics/skills](https://github.com/anthropics/skills) repositor
 - [Claude Agent Skills Playbook](./claude-agent-skills.md)
 - [Anthropic — Agent Skills overview](https://www.anthropic.com/news/skills)
 - [Anthropic engineering — Equipping agents for the real world with Agent Skills](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills)
+- [Anthropic – The Complete Guide to Building Skills for Claude (PDF)](../assets/guides/anthropic-claude-skills-guide.pdf)
+- [Claude Building Skills Guide](../04-guides/claude-building-skills-guide.md)

--- a/02-ai-agents/skills-design-patterns.md
+++ b/02-ai-agents/skills-design-patterns.md
@@ -1,0 +1,222 @@
+---
+title: "Claude Skills Design Patterns"
+tags: ["agents", "claude-agent", "skills"]
+last_updated: "2026-05-09"
+---
+
+# Claude Skills Design Patterns
+
+## Intent
+
+Use this guide to choose and implement the right structural pattern for a Claude Agent Skill. Each pattern includes a decision rule, a concrete pseudocode example, and the key techniques that make it work.
+
+For skill anatomy and technical requirements see [Anatomy of a Claude Agent Skill](./anatomy-of-a-skill.md). For testing guidance see [Skills Testing and Iteration](./skills-testing-iteration.md).
+
+---
+
+## Choosing your approach
+
+Before selecting a pattern, decide your framing:
+
+- **Problem-first** — users describe an outcome ("set up a project workspace") and the skill orchestrates the right tool calls. Best when users know what they want but not how to get it.
+- **Tool-first** — users already have a service connected via MCP ("I have Notion MCP") and the skill teaches Claude the optimal workflows. Best when users know the tool but not the best practices.
+
+Most skills lean one direction. The five patterns below cover both framings.
+
+---
+
+## Pattern 1: Sequential Workflow Orchestration
+
+**Use when:** The task requires multiple steps in a fixed order, where each step depends on the output of the previous one.
+
+**Example — customer onboarding:**
+
+```
+## Workflow: Onboard New Customer
+
+### Step 1: Create account
+Call MCP tool: create_customer
+Parameters: name, email, company
+
+### Step 2: Set up payment
+Call MCP tool: setup_payment_method
+Wait for: payment method verification confirmed
+
+### Step 3: Create subscription
+Call MCP tool: create_subscription
+Parameters: plan_id, customer_id (from Step 1 result)
+
+### Step 4: Send welcome email
+Call MCP tool: send_email
+Template: welcome_email_template
+```
+
+**Key techniques:**
+- Number each step explicitly — Claude will not reorder numbered steps.
+- Pass output from one step as named input to the next.
+- Add a validation check before each irreversible action.
+- Include rollback instructions for failure at each stage.
+
+---
+
+## Pattern 2: Multi-MCP Coordination
+
+**Use when:** The workflow spans multiple services that each hold part of the data or action surface.
+
+**Example — design-to-development handoff:**
+
+```
+### Phase 1: Export from Figma (Figma MCP)
+1. Export design assets
+2. Generate design specifications
+3. Create asset manifest
+
+### Phase 2: Store assets (Drive MCP)
+1. Create project folder
+2. Upload all assets
+3. Generate shareable links
+
+### Phase 3: Create tasks (Linear MCP)
+1. Create development tasks
+2. Attach asset links
+3. Assign to engineering team
+
+### Phase 4: Notify team (Slack MCP)
+1. Post handoff summary to #engineering
+2. Include asset links and task references
+```
+
+**Key techniques:**
+- One phase per MCP service — keeps responsibilities clear.
+- Validate the output of each phase before calling the next service.
+- Handle the case where one MCP service is unavailable without failing the entire workflow.
+- Use centralized error handling rather than per-step try/catch logic.
+
+---
+
+## Pattern 3: Iterative Refinement
+
+**Use when:** Output quality improves with review-and-revise cycles, and a single pass is not reliable enough.
+
+**Example — report generation:**
+
+```
+### Initial draft
+1. Fetch data via MCP
+2. Generate first draft
+3. Save to temporary file
+
+### Quality check
+1. Run validation: scripts/check_report.py
+2. Identify issues:
+   - Missing required sections
+   - Inconsistent formatting
+   - Data values that do not match source
+
+### Refinement loop
+1. Address each identified issue
+2. Regenerate affected sections
+3. Re-run validation
+4. Repeat until all checks pass (maximum 3 iterations)
+
+### Finalisation
+1. Apply final formatting
+2. Generate executive summary
+3. Save final version
+```
+
+**Key techniques:**
+- Define explicit quality criteria — do not rely on Claude's judgement alone.
+- Set a maximum iteration count to prevent infinite loops.
+- Use validation scripts in `scripts/` where checks must be deterministic.
+- Distinguish between "fix and retry" issues and "escalate to human" issues.
+
+---
+
+## Pattern 4: Context-Aware Tool Selection
+
+**Use when:** The same end goal requires different tools depending on the characteristics of the input.
+
+**Example — smart file storage:**
+
+```
+### Decision tree
+1. Check file type and size:
+   - Large files (> 10 MB): use cloud storage MCP
+   - Collaborative documents: use Notion/Docs MCP
+   - Code files: use GitHub MCP
+   - Temporary files: use local storage
+
+### Execute storage
+- Call the selected MCP tool
+- Apply service-specific metadata
+- Generate access link
+
+### Inform the user
+- Explain which storage was chosen and why
+```
+
+**Key techniques:**
+- Make decision criteria explicit and unambiguous — avoid vague conditions like "large files" without a defined threshold.
+- Always provide a fallback for the case where the preferred tool is unavailable.
+- Tell the user which path was taken and why, so they can override if needed.
+
+---
+
+## Pattern 5: Domain-Specific Intelligence
+
+**Use when:** The skill adds specialist knowledge or compliance logic that goes beyond what the tool itself enforces.
+
+**Example — payment processing with compliance:**
+
+```
+### Pre-processing compliance check
+1. Fetch transaction details via MCP
+2. Apply compliance rules:
+   - Check against sanctions lists
+   - Verify jurisdiction allowances
+   - Assess fraud risk level
+3. Document the compliance decision
+
+### Processing
+IF compliance passed:
+  - Call payment processing MCP tool
+  - Apply fraud-check parameters
+  - Record transaction ID
+ELSE:
+  - Flag transaction for manual review
+  - Create compliance case with reason code
+
+### Audit trail
+- Log all compliance checks with timestamps
+- Record every processing decision
+- Generate audit report for the session
+```
+
+**Key techniques:**
+- Run compliance or safety checks *before* taking any irreversible action.
+- Make every decision auditable — log both the check and the outcome.
+- Embed the "when to escalate to a human" rule explicitly in the instructions.
+- Keep long domain rules in a `references/` sibling file so `SKILL.md` stays under 5 000 tokens.
+
+---
+
+## Pattern selection guide
+
+| Situation | Recommended pattern |
+|---|---|
+| Steps must happen in strict order | Sequential Workflow Orchestration |
+| Workflow touches more than one service | Multi-MCP Coordination |
+| First-pass output is often imperfect | Iterative Refinement |
+| Same goal, multiple valid tool paths | Context-Aware Tool Selection |
+| Embedded rules, compliance, or expertise | Domain-Specific Intelligence |
+
+---
+
+## References
+
+- [Anatomy of a Claude Agent Skill](./anatomy-of-a-skill.md)
+- [Claude Building Skills Guide](../04-guides/claude-building-skills-guide.md)
+- [Skills Testing and Iteration](./skills-testing-iteration.md)
+- [Anthropic – The Complete Guide to Building Skills for Claude (PDF)](../assets/guides/anthropic-claude-skills-guide.pdf)
+- [GitHub — anthropics/skills repository](https://github.com/anthropics/skills)

--- a/02-ai-agents/skills-testing-iteration.md
+++ b/02-ai-agents/skills-testing-iteration.md
@@ -1,0 +1,161 @@
+---
+title: "Skills Testing and Iteration"
+tags: ["agents", "claude-agent", "skills"]
+last_updated: "2026-05-09"
+---
+
+# Skills Testing and Iteration
+
+## Intent
+
+Use this guide to validate a Claude Agent Skill before deployment and to improve it after release. Covers three testing tiers, trigger and functional test design, performance baselines, the `skill-creator` tool, and how to diagnose and fix under/over-triggering and execution failures.
+
+---
+
+## Testing tiers
+
+Choose the tier that matches your quality requirements and audience size.
+
+| Tier | Method | When to use |
+|---|---|---|
+| **Manual** | Run queries in Claude.ai and observe behaviour | First-pass validation, fast iteration |
+| **Scripted** | Automate test cases in Claude Code | Repeatable validation across skill changes |
+| **Programmatic** | Build evaluation suites via the Skills API | Production-grade skills, large user base |
+
+**Pro tip:** Iterate on a single challenging task until Claude succeeds, then extract that winning approach into the skill. This is faster than broad test coverage from the start. Once you have a working foundation, expand to a full suite.
+
+---
+
+## 1. Triggering tests
+
+**Goal:** Ensure the skill loads at the right times — and only then.
+
+Build two lists before you upload:
+
+```
+Should trigger:
+- "Help me set up a new ProjectHub workspace"
+- "I need to create a project in ProjectHub"
+- "Initialise a ProjectHub project for Q4 planning"
+
+Should NOT trigger:
+- "What's the weather today?"
+- "Help me write Python code"
+- "Create a spreadsheet"
+```
+
+Run each prompt with the skill enabled. Track how often it loads automatically vs. requires explicit invocation. Target: auto-loads on ≥ 90% of "should trigger" prompts, never loads on "should NOT trigger" prompts.
+
+**Debug shortcut:** Ask Claude `"When would you use the [skill-name] skill?"` — it will quote the description back verbatim. Adjust the description based on what is missing or too generic.
+
+---
+
+## 2. Functional tests
+
+**Goal:** Verify the skill produces correct outputs for representative inputs.
+
+Use a Given/When/Then format:
+
+```
+Test: Create project with tasks
+Given: Project name "Q4 Planning", 5 task descriptions
+When: Skill executes the workflow
+Then:
+  - Project exists in the target service
+  - All 5 tasks are created with correct properties
+  - Tasks are linked to the project
+  - No API errors occur
+```
+
+Cover these four cases at minimum:
+
+- **Happy path** — standard input, expected output
+- **Missing data** — required field absent; skill should prompt for it, not fail silently
+- **MCP error** — simulate a failed tool call; skill should handle it gracefully
+- **Edge case** — unusual but valid input (empty list, maximum-length string, special characters)
+
+---
+
+## 3. Performance comparison
+
+**Goal:** Prove the skill saves effort relative to unaided prompting.
+
+Run the same task with and without the skill enabled, then measure:
+
+| Metric | Without skill | With skill |
+|---|---|---|
+| User messages to completion | e.g. 15 | e.g. 2 |
+| Failed / retried tool calls | e.g. 3 | e.g. 0 |
+| Total tokens consumed | e.g. 12 000 | e.g. 6 000 |
+
+Compare these numbers against the quantitative success criteria you set during planning. See [Claude Building Skills Guide](../04-guides/claude-building-skills-guide.md) for the full success criteria framework.
+
+---
+
+## Using the skill-creator skill
+
+The `skill-creator` skill is built into Claude.ai and available for Claude Code. It helps you draft and improve skills without starting from scratch.
+
+**Create a skill from a description:**
+
+```
+"Use the skill-creator skill to help me build a skill for [your use case]"
+```
+
+skill-creator prompts you for use case definitions, generates properly formatted `SKILL.md` frontmatter, and suggests trigger phrases and structure.
+
+**Review an existing skill:**
+
+```
+"Review this skill and suggest improvements"
+```
+
+It flags vague descriptions, missing triggers, structural problems, and potential over/under-triggering risks, and suggests test cases based on the skill's stated purpose.
+
+**Iterate after real-world use:**
+
+```
+"Use the issues found in this conversation to improve how the skill handles [edge case]"
+```
+
+> Note: skill-creator designs and refines skills. It does not execute automated test suites or produce quantitative evaluation results.
+
+---
+
+## Iteration based on feedback
+
+Skills are living documents. Use these signals to know what to fix.
+
+### Under-triggering
+
+**Signals:** Skill never loads automatically; users manually enable it; support questions about when to use it.
+
+**Fix:** Add more specific trigger phrases and domain-specific keywords to the `description`. If users say "OCR a document" but your description only mentions "extract text", add "OCR" explicitly.
+
+### Over-triggering
+
+**Signals:** Skill loads for unrelated queries; users disable it; output feels irrelevant.
+
+**Fix:** Add negative triggers and narrow the scope:
+
+```
+description: PayFlow payment processing for e-commerce. Use specifically
+for online payment workflows. Do NOT use for general financial queries
+or reporting.
+```
+
+### Execution issues
+
+**Signals:** Inconsistent outputs; API call failures; users need to correct Claude mid-workflow.
+
+**Fix:** Improve instruction specificity, move verbose content to `references/` sibling files, and add explicit error-handling steps for known failure modes. For critical validations, bundle a script that performs checks programmatically — code is deterministic, language interpretation is not.
+
+---
+
+## References
+
+- [Anatomy of a Claude Agent Skill](./anatomy-of-a-skill.md)
+- [Claude Building Skills Guide](../04-guides/claude-building-skills-guide.md)
+- [Skills Design Patterns](./skills-design-patterns.md)
+- [Anthropic – The Complete Guide to Building Skills for Claude (PDF)](../assets/guides/anthropic-claude-skills-guide.pdf)
+- [GitHub — anthropics/skills repository](https://github.com/anthropics/skills)

--- a/04-guides/claude-building-skills-guide.md
+++ b/04-guides/claude-building-skills-guide.md
@@ -117,5 +117,8 @@ Why bad: too vague and lacks triggers.
 ## Practical takeaway
 If prompt engineering helped you get one-off results, skills help you operationalize those results at scale. Start by creating one narrowly scoped skill with strong triggers and clear step-by-step instructions, then compose it with others as your workflows grow.
 
-## Source context
-This guide is based on your provided summary of Anthropic’s skill-building framework and aligned with your existing **[Claude Agent Skills Playbook](../02-ai-agents/claude-agent-skills.md)**.
+## References
+- [Anthropic – The Complete Guide to Building Skills for Claude (PDF)](../assets/guides/anthropic-claude-skills-guide.pdf)
+- [Anthropic — Skills for Claude Agents](https://www.anthropic.com/news/skills)
+- [Anatomy of a Claude Agent Skill](../02-ai-agents/anatomy-of-a-skill.md)
+- [Claude Agent Skills Playbook](../02-ai-agents/claude-agent-skills.md)

--- a/04-guides/claude-building-skills-guide.md
+++ b/04-guides/claude-building-skills-guide.md
@@ -65,6 +65,53 @@ Use layered loading so Claude pulls only what is needed:
 
 ---
 
+## Planning your skill: use-case methodology
+
+Before writing any instructions, define 2–3 concrete use cases your skill must handle. A good use case has four parts:
+
+| Part | What to define |
+|---|---|
+| **Trigger** | The exact phrase or intent that should activate the skill |
+| **Steps** | The ordered actions Claude must take |
+| **Tools needed** | Built-in Claude capabilities or specific MCP tools |
+| **Result** | What a successful completion looks like |
+
+**Example:**
+
+```
+Trigger: "help me plan this sprint" or "create sprint tasks"
+Steps:
+  1. Fetch current project status from Linear (via MCP)
+  2. Analyse team velocity and capacity
+  3. Suggest task prioritisation
+  4. Create tasks with proper labels and estimates
+Result: Fully planned sprint with tasks created in Linear
+```
+
+Ask yourself before building:
+- What does a user want to accomplish?
+- What multi-step workflow does this require?
+- Which tools are needed (built-in Claude capabilities or MCP)?
+- What domain knowledge or best practices should be embedded?
+
+---
+
+## Defining success criteria
+
+Set measurable targets before testing so you know when to stop iterating.
+
+**Quantitative:**
+- Skill triggers on ≥ 90% of relevant queries — run 10–20 representative prompts and count automatic loads vs. manual invocations.
+- Target tool call count per workflow — compare with and without the skill to confirm it reduces back-and-forth.
+- Zero failed API calls per run — monitor MCP server logs during testing for retry rates and error codes.
+
+**Qualitative:**
+- Users do not need to prompt Claude for next steps during the workflow.
+- Workflow completes without user correction across 3–5 repeated runs.
+- A new user can accomplish the task on first try with minimal guidance.
+
+---
+
 ## Critical technical requirements
 
 ### File structure
@@ -73,7 +120,7 @@ Use layered loading so Claude pulls only what is needed:
 - Do **not** use `README.md` inside a skill folder
 
 ### Required YAML frontmatter
-- `name`: should be in **UPPER-CASE**
+- `name`: must be in **kebab-case** (lowercase letters, numbers, and hyphens only)
 - `description`: must explain
   - what the skill does,
   - when to use it,
@@ -111,6 +158,38 @@ Why bad: too vague and lacks triggers.
 
 ### 5) Domain-Specific Intelligence
 - Encodes specialized expertise beyond basic tool usage
+
+---
+
+## Distribution essentials
+
+### Installing a skill
+
+**Claude.ai / Claude Code (individual):**
+1. Zip the skill folder: `zip -r my-skill.zip my-skill/`
+2. Claude.ai → Settings → Capabilities → Skills → Upload skill
+3. For Claude Code: place the unzipped folder in `.claude/skills/`
+
+**Organisation-wide:** Admins can deploy skills workspace-wide from the Anthropic console. Skills update automatically for all users without manual reinstallation.
+
+### Using skills via the API
+
+Add the `container.skills` parameter and the required beta headers to any Messages API request:
+
+```python
+headers = {
+    "anthropic-beta": "code-execution-2025-08-25,skills-2025-10-02,files-api-2025-04-14"
+}
+```
+
+Up to 8 skills per request. Skills require the Code Execution Tool beta for their sandboxed runtime environment.
+
+| Use case | Best surface |
+|---|---|
+| End users interacting directly | Claude.ai / Claude Code |
+| Manual testing during development | Claude.ai / Claude Code |
+| Applications using skills programmatically | API |
+| Automated pipelines and agent systems | API |
 
 ---
 

--- a/external-sources.md
+++ b/external-sources.md
@@ -22,6 +22,7 @@
 - [Anthropic Skilljar - Claude Certified Architect Foundations Access Request](https://anthropic.skilljar.com/claude-certified-architect-foundations-access-request)
 - [Anthropic Skilljar - Claude Code in Action](https://anthropic.skilljar.com/claude-code-in-action)
 - [Anthropic — Skills for Claude Agents](https://www.anthropic.com/news/skills)
+- [Anthropic – The Complete Guide to Building Skills for Claude (PDF)](assets/guides/anthropic-claude-skills-guide.pdf)
 - [arXiv 2512.15943 — Tool-calling specialization beats scale (PDF)](https://arxiv.org/pdf/2512.15943)
 
 ### B

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,8 @@ nav:
     - Anatomy of a Claude Agent Skill: 02-ai-agents/anatomy-of-a-skill.md
     - Claude Agent Skills Playbook: 02-ai-agents/claude-agent-skills.md
     - Claude Building Skills Guide: 04-guides/claude-building-skills-guide.md
+    - Skills Design Patterns: 02-ai-agents/skills-design-patterns.md
+    - Skills Testing and Iteration: 02-ai-agents/skills-testing-iteration.md
     - Claude AI vs Claude Code vs Claude Cowork: 05-tools/claude-ai-vs-code-vs-cowork.md
     - Cowork Tool Selection Tutorial: 05-tools/cowork-tool-selection-tutorial.md
     - Claude Code Tool Guide: 05-tools/claude-code-tool-guide.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
     - Best AI Apps for 2026: 05-tools/best-ai-apps-2026.md
     - Anatomy of a Claude Agent Skill: 02-ai-agents/anatomy-of-a-skill.md
     - Claude Agent Skills Playbook: 02-ai-agents/claude-agent-skills.md
+    - Claude Building Skills Guide: 04-guides/claude-building-skills-guide.md
     - Claude AI vs Claude Code vs Claude Cowork: 05-tools/claude-ai-vs-code-vs-cowork.md
     - Cowork Tool Selection Tutorial: 05-tools/cowork-tool-selection-tutorial.md
     - Claude Code Tool Guide: 05-tools/claude-code-tool-guide.md
@@ -97,7 +98,6 @@ nav:
     - Reasoning vs. Classic LLMs: 04-guides/reasoning-vs-classic-llms.md
     - Reasoning vs. Classic LLMs (DE): 04-guides/reasoning-vs-classic-llms-de.md
     - Codex Agent Prompting Guide: 04-guides/codex-agent-prompting-guide.md
-    - Claude Building Skills Guide: 04-guides/claude-building-skills-guide.md
     - Fine-Tune an Open Source LLM with Claude: 04-guides/claude-fine-tune-llm.md
     - FunctionGemma Fine-Tuning + Local Serving (LM Studio): 04-guides/finetune-functiongemma.md
     - Best Model Providers for AI Agents for 2026: 02-ai-agents/models-for-ai-agents-2026.md


### PR DESCRIPTION
- Register anthropic-claude-skills-guide.pdf in external-sources.md
- Replace informal source note in claude-building-skills-guide.md with a
  proper References section linking to the PDF, Anthropic news page,
  anatomy-of-a-skill, and the skills playbook
- Add PDF and claude-building-skills-guide cross-references to the
  References section in anatomy-of-a-skill.md
- Move Claude Building Skills Guide from Guides to Tools in mkdocs.yml
  so all three skill files (anatomy, playbook, guide) sit together

https://claude.ai/code/session_01GdPHVDbKUP4uKjmNMoWPkN