### PR TITLE
Add HTML tutorial page for AI agents overview

### DIFF
--- a/02-ai-agents/01-foundations/ai-agents-overview.html
+++ b/02-ai-agents/01-foundations/ai-agents-overview.html
@@ -1,0 +1,814 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Understanding AI Agents – Prompting Blueprints</title>
+  <meta name="description" content="A comprehensive overview of AI agents: types, architecture, workflows, and how to build production-grade agents." />
+  <style>
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+    :root {
+      --cyan:    #00d4ff;
+      --purple:  #8a2be2;
+      --green:   #00ff88;
+      --orange:  #ff8c42;
+      --pink:    #ff4d9b;
+      --bg-deep: #07071a;
+      --bg-mid:  #0f0f2d;
+      --bg-card: rgba(255,255,255,0.04);
+      --border:  rgba(255,255,255,0.08);
+      --text:    #e8eaf6;
+      --muted:   rgba(232,234,246,0.55);
+      --radius:  16px;
+    }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+      background: var(--bg-deep);
+      color: var(--text);
+      line-height: 1.7;
+      overflow-x: hidden;
+    }
+
+    /* ── Animated background ── */
+    body::before {
+      content: '';
+      position: fixed; inset: 0; z-index: -1;
+      background:
+        radial-gradient(ellipse 80% 60% at 10% 5%,  rgba(138,43,226,.18) 0%, transparent 60%),
+        radial-gradient(ellipse 60% 50% at 90% 90%, rgba(0,212,255,.12) 0%, transparent 55%),
+        radial-gradient(ellipse 50% 40% at 50% 50%, rgba(0,255,136,.06) 0%, transparent 60%),
+        linear-gradient(160deg, #07071a 0%, #0f0f2d 50%, #07071a 100%);
+    }
+
+    /* ── Nav ── */
+    nav {
+      position: sticky; top: 0; z-index: 100;
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 14px 32px;
+      background: rgba(7,7,26,.85);
+      backdrop-filter: blur(18px);
+      border-bottom: 1px solid var(--border);
+    }
+    .nav-brand { font-size: .9rem; color: var(--muted); text-decoration: none; }
+    .nav-brand span { color: var(--cyan); font-weight: 600; }
+    .nav-links { display: flex; gap: 20px; list-style: none; }
+    .nav-links a {
+      font-size: .82rem; color: var(--muted); text-decoration: none;
+      transition: color .2s;
+    }
+    .nav-links a:hover { color: var(--cyan); }
+
+    /* ── Layout ── */
+    .wrapper { max-width: 1100px; margin: 0 auto; padding: 0 24px; }
+
+    /* ── Hero ── */
+    .hero {
+      padding: 90px 24px 60px;
+      text-align: center;
+      position: relative;
+    }
+    .hero-eyebrow {
+      display: inline-block; margin-bottom: 16px;
+      padding: 6px 18px; border-radius: 999px;
+      background: rgba(0,212,255,.1); border: 1px solid rgba(0,212,255,.3);
+      font-size: .8rem; color: var(--cyan); letter-spacing: .08em; text-transform: uppercase;
+    }
+    .hero h1 {
+      font-size: clamp(2.4rem, 6vw, 4rem);
+      font-weight: 800; line-height: 1.15;
+      background: linear-gradient(135deg, #fff 30%, var(--cyan) 70%, var(--purple) 100%);
+      -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+      background-clip: text; margin-bottom: 20px;
+    }
+    .hero p {
+      max-width: 680px; margin: 0 auto 36px;
+      font-size: 1.1rem; color: var(--muted);
+    }
+    .hero-cta {
+      display: inline-flex; align-items: center; gap: 10px;
+      padding: 14px 28px; border-radius: 999px;
+      background: linear-gradient(135deg, var(--cyan), var(--purple));
+      color: #fff; font-weight: 700; font-size: .95rem;
+      text-decoration: none; transition: transform .25s, box-shadow .25s;
+      box-shadow: 0 6px 30px rgba(0,212,255,.3);
+    }
+    .hero-cta:hover { transform: translateY(-3px); box-shadow: 0 12px 40px rgba(0,212,255,.45); }
+    .hero-cta svg { width: 18px; height: 18px; }
+
+    /* ── Section ── */
+    section { padding: 72px 0; }
+    .section-label {
+      display: inline-block; margin-bottom: 12px;
+      font-size: .75rem; color: var(--cyan); letter-spacing: .12em;
+      text-transform: uppercase; font-weight: 700;
+    }
+    section > .wrapper > h2 {
+      font-size: clamp(1.6rem, 4vw, 2.2rem); font-weight: 700; margin-bottom: 12px;
+    }
+    section > .wrapper > .section-intro {
+      max-width: 720px; color: var(--muted); margin-bottom: 48px; font-size: 1rem;
+    }
+
+    /* ── Glass card ── */
+    .card {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      backdrop-filter: blur(10px);
+      padding: 28px;
+      transition: transform .3s, border-color .3s, box-shadow .3s;
+    }
+    .card:hover {
+      transform: translateY(-6px);
+      border-color: rgba(0,212,255,.35);
+      box-shadow: 0 16px 48px rgba(0,212,255,.12);
+    }
+    .card-icon {
+      width: 48px; height: 48px; border-radius: 12px;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 1.5rem; margin-bottom: 16px;
+    }
+    .card h3 { font-size: 1.1rem; font-weight: 700; margin-bottom: 8px; }
+    .card p { font-size: .9rem; color: var(--muted); }
+
+    /* ── Grid layouts ── */
+    .grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+    .grid-2 { display: grid; grid-template-columns: repeat(2, 1fr); gap: 20px; }
+    .grid-4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: 20px; }
+
+    /* ── History timeline ── */
+    .timeline { position: relative; padding-left: 40px; }
+    .timeline::before {
+      content: ''; position: absolute; left: 14px; top: 0; bottom: 0;
+      width: 2px;
+      background: linear-gradient(to bottom, var(--cyan), var(--purple));
+    }
+    .timeline-item { position: relative; margin-bottom: 36px; }
+    .timeline-item::before {
+      content: ''; position: absolute; left: -33px; top: 6px;
+      width: 14px; height: 14px; border-radius: 50%;
+      background: var(--cyan); border: 3px solid var(--bg-deep);
+      box-shadow: 0 0 10px var(--cyan);
+    }
+    .timeline-date {
+      font-size: .78rem; color: var(--cyan); font-weight: 700;
+      letter-spacing: .05em; margin-bottom: 4px;
+    }
+    .timeline-item h3 { font-size: 1rem; font-weight: 600; margin-bottom: 6px; }
+    .timeline-item p { font-size: .88rem; color: var(--muted); }
+    .timeline-item a { color: var(--cyan); text-decoration: none; }
+    .timeline-item a:hover { text-decoration: underline; }
+
+    /* ── Capability accent colors ── */
+    .accent-cyan  .card-icon { background: rgba(0,212,255,.12);  color: var(--cyan); }
+    .accent-purple .card-icon { background: rgba(138,43,226,.15); color: #b57bee; }
+    .accent-green .card-icon  { background: rgba(0,255,136,.1);   color: var(--green); }
+    .accent-orange .card-icon { background: rgba(255,140,66,.12);  color: var(--orange); }
+    .accent-pink  .card-icon  { background: rgba(255,77,155,.1);   color: var(--pink); }
+
+    /* ── Architecture layer ── */
+    .arch-stack { display: flex; flex-direction: column; gap: 12px; }
+    .arch-layer {
+      display: grid; grid-template-columns: 120px 1fr;
+      align-items: center; gap: 20px;
+      padding: 18px 24px; border-radius: 12px;
+      background: var(--bg-card); border: 1px solid var(--border);
+      transition: border-color .3s;
+    }
+    .arch-layer:hover { border-color: rgba(0,212,255,.35); }
+    .layer-num {
+      font-size: .72rem; font-weight: 700; letter-spacing: .1em;
+      text-transform: uppercase; color: var(--cyan);
+      border-right: 1px solid var(--border); padding-right: 16px;
+    }
+    .arch-layer h3 { font-size: .95rem; font-weight: 700; margin-bottom: 3px; }
+    .arch-layer p  { font-size: .85rem; color: var(--muted); }
+
+    /* ── Agent type cards ── */
+    .agent-card {
+      border-radius: var(--radius); padding: 28px;
+      border: 1px solid var(--border);
+      background: var(--bg-card); backdrop-filter: blur(10px);
+      transition: transform .3s, box-shadow .3s;
+    }
+    .agent-card:hover { transform: translateY(-6px); box-shadow: 0 20px 50px rgba(0,0,0,.4); }
+    .agent-badge {
+      display: inline-block; padding: 4px 14px; border-radius: 999px;
+      font-size: .72rem; font-weight: 700; letter-spacing: .08em;
+      text-transform: uppercase; margin-bottom: 14px;
+    }
+    .badge-retrieval { background: rgba(0,212,255,.15); color: var(--cyan); border: 1px solid rgba(0,212,255,.3); }
+    .badge-task      { background: rgba(138,43,226,.15); color: #b57bee;    border: 1px solid rgba(138,43,226,.3); }
+    .badge-autonomous{ background: rgba(255,140,66,.15);  color: var(--orange); border: 1px solid rgba(255,140,66,.3); }
+    .agent-card h3   { font-size: 1.15rem; font-weight: 700; margin-bottom: 10px; }
+    .agent-meta { display: flex; flex-direction: column; gap: 10px; margin-top: 14px; }
+    .meta-row { display: flex; gap: 8px; align-items: flex-start; font-size: .85rem; }
+    .meta-label { color: var(--cyan); font-weight: 600; white-space: nowrap; }
+    .meta-val { color: var(--muted); }
+
+    /* ── Workflow cards ── */
+    .workflow-cards { display: grid; grid-template-columns: repeat(3,1fr); gap: 20px; }
+    .workflow-card {
+      border-radius: var(--radius); overflow: hidden;
+      border: 1px solid var(--border);
+      background: var(--bg-card); backdrop-filter: blur(10px);
+      transition: transform .3s, box-shadow .3s;
+    }
+    .workflow-card:hover { transform: translateY(-6px); box-shadow: 0 20px 50px rgba(0,0,0,.4); }
+    .workflow-img { width: 100%; aspect-ratio: 16/9; object-fit: contain; background: rgba(255,255,255,.03); }
+    .workflow-body { padding: 20px; }
+    .workflow-body h3 { font-size: 1rem; font-weight: 700; margin-bottom: 6px; }
+    .workflow-body .when { font-size: .8rem; color: var(--cyan); margin-bottom: 8px; font-weight: 600; }
+    .workflow-body p { font-size: .85rem; color: var(--muted); }
+
+    /* ── Build steps ── */
+    .steps { display: flex; flex-direction: column; gap: 16px; }
+    .step {
+      display: grid; grid-template-columns: 52px 1fr;
+      gap: 20px; align-items: start;
+      background: var(--bg-card); border: 1px solid var(--border);
+      border-radius: var(--radius); padding: 22px 24px;
+      transition: border-color .3s, transform .3s;
+    }
+    .step:hover { border-color: rgba(0,212,255,.3); transform: translateX(6px); }
+    .step-num {
+      width: 40px; height: 40px; border-radius: 50%;
+      display: flex; align-items: center; justify-content: center;
+      font-weight: 800; font-size: .95rem;
+      background: linear-gradient(135deg, var(--cyan), var(--purple));
+      color: #fff; flex-shrink: 0;
+    }
+    .step h3 { font-size: 1rem; font-weight: 700; margin-bottom: 6px; }
+    .step ul { padding-left: 18px; }
+    .step li { font-size: .875rem; color: var(--muted); margin-bottom: 4px; }
+    .step code {
+      background: rgba(255,255,255,.08); padding: 1px 7px; border-radius: 5px;
+      font-size: .85em; font-family: 'Cascadia Code', 'Fira Code', monospace;
+      color: var(--cyan);
+    }
+
+    /* ── Frameworks table ── */
+    .table-wrap { overflow-x: auto; border-radius: var(--radius); }
+    table {
+      width: 100%; border-collapse: collapse;
+      font-size: .85rem;
+    }
+    thead th {
+      padding: 14px 16px; text-align: left;
+      background: rgba(0,212,255,.07); border-bottom: 1px solid rgba(0,212,255,.2);
+      color: var(--cyan); font-weight: 700; letter-spacing: .04em;
+      white-space: nowrap;
+    }
+    tbody tr { border-bottom: 1px solid var(--border); transition: background .2s; }
+    tbody tr:hover { background: rgba(255,255,255,.04); }
+    tbody td { padding: 12px 16px; color: var(--muted); vertical-align: middle; }
+    tbody td a { color: var(--cyan); text-decoration: none; }
+    tbody td a:hover { text-decoration: underline; }
+    .check-yes { color: var(--green); font-weight: 700; }
+    .check-no  { color: rgba(255,255,255,.25); }
+
+    /* ── Agent types comparison table ── */
+    .type-table-wrap { overflow-x: auto; margin-top: 32px; border-radius: var(--radius); border: 1px solid var(--border); }
+    .type-table { width: 100%; border-collapse: collapse; font-size: .88rem; }
+    .type-table thead th {
+      padding: 14px 20px; text-align: left;
+      background: rgba(255,255,255,.04); border-bottom: 1px solid var(--border);
+      color: var(--text); font-weight: 700;
+    }
+    .type-table tbody td { padding: 12px 20px; color: var(--muted); border-bottom: 1px solid var(--border); }
+    .type-table tbody tr:last-child td { border-bottom: none; }
+    .type-table tbody tr:hover { background: rgba(255,255,255,.03); }
+
+    /* ── Callout ── */
+    .callout {
+      margin-top: 32px; padding: 18px 24px; border-radius: 12px;
+      background: rgba(0,212,255,.07); border-left: 4px solid var(--cyan);
+      font-size: .9rem; color: var(--muted);
+    }
+    .callout strong { color: var(--cyan); }
+
+    /* ── Quick checks ── */
+    .checks { display: flex; flex-direction: column; gap: 10px; margin-top: 24px; }
+    .check-item {
+      display: flex; align-items: flex-start; gap: 12px;
+      padding: 14px 18px; border-radius: 10px;
+      background: rgba(0,255,136,.05); border: 1px solid rgba(0,255,136,.12);
+      font-size: .88rem; color: var(--muted);
+    }
+    .check-item::before { content: '✓'; color: var(--green); font-weight: 800; flex-shrink: 0; }
+
+    /* ── References ── */
+    .refs { display: flex; flex-direction: column; gap: 8px; }
+    .ref-item {
+      padding: 12px 18px; border-radius: 10px;
+      background: var(--bg-card); border: 1px solid var(--border);
+      font-size: .85rem; color: var(--muted);
+      display: flex; align-items: center; gap: 10px;
+    }
+    .ref-item::before { content: '↗'; color: var(--cyan); font-weight: 700; }
+    .ref-item a { color: var(--cyan); text-decoration: none; }
+    .ref-item a:hover { text-decoration: underline; }
+
+    /* ── Divider ── */
+    .section-divider {
+      height: 1px; margin: 0;
+      background: linear-gradient(to right, transparent, rgba(255,255,255,.06), transparent);
+    }
+
+    /* ── Footer ── */
+    footer {
+      padding: 40px 24px; text-align: center;
+      font-size: .82rem; color: var(--muted);
+      border-top: 1px solid var(--border);
+    }
+    footer a { color: var(--cyan); text-decoration: none; }
+
+    /* ── Responsive ── */
+    @media (max-width: 900px) {
+      .grid-3, .workflow-cards { grid-template-columns: 1fr; }
+      .grid-4 { grid-template-columns: repeat(2,1fr); }
+    }
+    @media (max-width: 640px) {
+      .grid-2, .grid-4 { grid-template-columns: 1fr; }
+      .arch-layer { grid-template-columns: 1fr; }
+      .layer-num { border-right: none; border-bottom: 1px solid var(--border); padding-right: 0; padding-bottom: 8px; }
+      .step { grid-template-columns: 1fr; }
+      .step-num { margin-bottom: 8px; }
+      nav { flex-wrap: wrap; gap: 10px; }
+      .nav-links { flex-wrap: wrap; gap: 12px; }
+    }
+
+    /* ── Fade-in animation ── */
+    @keyframes fadeUp {
+      from { opacity: 0; transform: translateY(30px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+    .hero h1, .hero p, .hero-cta { animation: fadeUp .7s ease both; }
+    .hero p    { animation-delay: .15s; }
+    .hero-cta  { animation-delay: .3s; }
+  </style>
+</head>
+<body>
+
+<!-- ── Navigation ── -->
+<nav>
+  <a class="nav-brand" href="../../README.md">
+    Prompting Blueprints &rsaquo; <span>AI Agents Overview</span>
+  </a>
+  <ul class="nav-links">
+    <li><a href="#overview">Overview</a></li>
+    <li><a href="#types">Agent Types</a></li>
+    <li><a href="#workflows">Workflows</a></li>
+    <li><a href="#build">Build Guide</a></li>
+    <li><a href="#frameworks">Frameworks</a></li>
+    <li><a href="#references">References</a></li>
+  </ul>
+</nav>
+
+<!-- ── Hero ── -->
+<header class="hero">
+  <span class="hero-eyebrow">02 · AI Agents · Foundations</span>
+  <h1>Understanding AI Agents</h1>
+  <p>AI agents combine language models with orchestrated tools and data sources to perceive real-world signals, plan multi-step solutions, and act autonomously on a user's behalf.</p>
+  <a class="hero-cta" href="https://youtu.be/bx-bcUWw2Wo" target="_blank" rel="noreferrer">
+    <svg viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>
+    Watch the AI Agents Overview
+  </a>
+</header>
+
+<div class="section-divider"></div>
+
+<!-- ── Overview ── -->
+<section id="overview">
+  <div class="wrapper">
+    <span class="section-label">Overview</span>
+    <h2>What Are AI Agents?</h2>
+    <p class="section-intro">Modern AI agents combine language models with orchestrated tools and data sources so they can observe real-world signals, plan multi-step solutions, and act autonomously or semi-autonomously on a user's behalf.</p>
+
+    <div class="grid-3">
+      <div class="card accent-cyan">
+        <div class="card-icon">👁️</div>
+        <h3>Perception</h3>
+        <p>Agents ingest structured and unstructured data, including natural language, to understand user intent and environmental context.</p>
+      </div>
+      <div class="card accent-purple">
+        <div class="card-icon">🧠</div>
+        <h3>Reasoning &amp; Planning</h3>
+        <p>They evaluate goals, decompose tasks, and determine next steps using chain-of-thought prompting and planning heuristics.</p>
+      </div>
+      <div class="card accent-green">
+        <div class="card-icon">⚡</div>
+        <h3>Action &amp; Learning</h3>
+        <p>Agents execute tasks by calling external tools, invoking APIs, or generating content — and refine behavior based on feedback loops.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- ── History ── -->
+<section id="history">
+  <div class="wrapper">
+    <span class="section-label">Brief History</span>
+    <h2>How We Got Here</h2>
+    <p class="section-intro">Modern agent design traces back to discrete prompt-engineering breakthroughs that made autonomous, multi-step reasoning possible.</p>
+
+    <div class="timeline">
+      <div class="timeline-item">
+        <div class="timeline-date">January 28, 2022</div>
+        <h3>Chain-of-Thought Prompting</h3>
+        <p>Wei et al. showed that guiding models through intermediate reasoning steps dramatically boosts multi-hop problem solving — setting the stage for agents that explain and justify decisions. <a href="https://arxiv.org/abs/2201.11903" target="_blank" rel="noreferrer">Read paper →</a></p>
+      </div>
+      <div class="timeline-item">
+        <div class="timeline-date">February 21, 2023</div>
+        <h3>The Persona Pattern</h3>
+        <p>Dr. Jules White introduced role-specific scaffolds that unlock tool selection and memory strategies — catalogued in the <a href="../../../03-prompts-and-patterns/prompt-pattern-catalogue.md">Prompt Pattern Catalogue</a> and via <a href="https://arxiv.org/abs/2302.11382" target="_blank" rel="noreferrer">White et al.</a></p>
+      </div>
+      <div class="timeline-item">
+        <div class="timeline-date">August 2023</div>
+        <h3>AI Planning Pattern</h3>
+        <p>White formalized the AI Planning pattern in <a href="https://www.vanderbilt.edu/datascience/2023/08/29/new-course-chatgpt-advanced-data-analysis-by-dr-jules-white-associate-professor-of-computer-science/" target="_blank" rel="noreferrer">ChatGPT Advanced Data Analysis</a>, encouraging practitioners to externalize goal decomposition before autonomous agent operation.</p>
+      </div>
+      <div class="timeline-item">
+        <div class="timeline-date">March 14, 2024</div>
+        <h3>LLM Agents for User Story Quality</h3>
+        <p>Our team published findings showing how structured planning bridges prompt templates and autonomous agent stacks. <a href="https://link.springer.com/chapter/10.1007/978-3-031-61154-4_8" target="_blank" rel="noreferrer">Zhang et al. →</a></p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- ── Architecture ── -->
+<section id="architecture">
+  <div class="wrapper">
+    <span class="section-label">Architecture</span>
+    <h2>Architectural Elements</h2>
+    <p class="section-intro">A production-grade AI agent is composed of four interlocking layers, each with distinct responsibilities.</p>
+
+    <div class="arch-stack">
+      <div class="arch-layer">
+        <div class="layer-num">Layer 1<br/>Interface</div>
+        <div>
+          <h3>Interface Layer</h3>
+          <p>Handles conversations, user prompts, and other inputs while presenting results back to the user.</p>
+        </div>
+      </div>
+      <div class="arch-layer">
+        <div class="layer-num">Layer 2<br/>Orchestration</div>
+        <div>
+          <h3>Orchestration Layer</h3>
+          <p>Coordinates models, tools, and memory components so the agent can decide what to do next.</p>
+        </div>
+      </div>
+      <div class="arch-layer">
+        <div class="layer-num">Layer 3<br/>Foundation</div>
+        <div>
+          <h3>Foundation Models &amp; Tools</h3>
+          <p>Provide language understanding, content generation, and the ability to interact with enterprise systems or third-party services.</p>
+        </div>
+      </div>
+      <div class="arch-layer">
+        <div class="layer-num">Layer 4<br/>Governance</div>
+        <div>
+          <h3>Governance &amp; Safety</h3>
+          <p>Enforces policies, monitors for misuse, and ensures responses stay aligned with organizational standards.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- ── Agent Types ── -->
+<section id="types">
+  <div class="wrapper">
+    <span class="section-label">Agent Types</span>
+    <h2>Spectrum of AI Agent Types</h2>
+    <p class="section-intro">Compare the common maturity levels to scope agent capabilities before adding orchestration, new tools, or autonomy.</p>
+
+    <img src="../../assets/other/types-of-ai-agents.png" alt="Spectrum of AI agent types showing Retrieval, Task, and Autonomous panels" style="width:100%; border-radius:var(--radius); border:1px solid var(--border); margin-bottom:32px;" />
+
+    <div class="grid-3">
+      <div class="agent-card">
+        <span class="agent-badge badge-retrieval">Retrieval</span>
+        <h3>Retrieval Agents</h3>
+        <p style="font-size:.88rem; color:var(--muted); margin-bottom:12px;">Tap grounding data, reason over snippets, summarize, and answer scoped questions.</p>
+        <div class="agent-meta">
+          <div class="meta-row"><span class="meta-label">Use when:</span><span class="meta-val">Grounded answers from approved documents or APIs without exposing full tool access.</span></div>
+          <div class="meta-row"><span class="meta-label">Core moves:</span><span class="meta-val">Chunk and embed data, route questions through retrieval-augmented prompts, explain citations inline.</span></div>
+          <div class="meta-row"><span class="meta-label">Design notes:</span><span class="meta-val">Prioritize latency, caching, and guardrails that stop hallucination outside the grounding corpus.</span></div>
+          <div class="meta-row"><span class="meta-label">Ideal scope:</span><span class="meta-val">Knowledge bases, policies, product catalogs, support wikis.</span></div>
+        </div>
+      </div>
+      <div class="agent-card">
+        <span class="agent-badge badge-task">Task</span>
+        <h3>Task Agents</h3>
+        <p style="font-size:.88rem; color:var(--muted); margin-bottom:12px;">Take direct actions, call tools, and automate multi-step jobs when asked.</p>
+        <div class="agent-meta">
+          <div class="meta-row"><span class="meta-label">Use when:</span><span class="meta-val">Users expect execution of predictable workflows — create tickets, summarize calls, update sheets.</span></div>
+          <div class="meta-row"><span class="meta-label">Core moves:</span><span class="meta-val">Invoke deterministic tools, log every action, request clarifications when a parameter is missing.</span></div>
+          <div class="meta-row"><span class="meta-label">Design notes:</span><span class="meta-val">Pair prompts with checklists, expose safe defaults, and track completion metrics per task template.</span></div>
+          <div class="meta-row"><span class="meta-label">Ideal scope:</span><span class="meta-val">Workflow automation, CRM updates, support triage, creative drafts.</span></div>
+        </div>
+      </div>
+      <div class="agent-card">
+        <span class="agent-badge badge-autonomous">Autonomous</span>
+        <h3>Autonomous Agents</h3>
+        <p style="font-size:.88rem; color:var(--muted); margin-bottom:12px;">Plan dynamically, orchestrate other agents, learn from feedback, and escalate when needed.</p>
+        <div class="agent-meta">
+          <div class="meta-row"><span class="meta-label">Use when:</span><span class="meta-val">Work requires multi-day plans, branching decision trees, or hand-offs across specialized agents.</span></div>
+          <div class="meta-row"><span class="meta-label">Core moves:</span><span class="meta-val">Maintain scratchpads, spawn or orchestrate sub-agents, decide when to escalate to humans.</span></div>
+          <div class="meta-row"><span class="meta-label">Design notes:</span><span class="meta-val">Treat planning graphs as infrastructure, layer evals for alignment/safety, and add memory policies.</span></div>
+          <div class="meta-row"><span class="meta-label">Ideal scope:</span><span class="meta-val">Mission-critical copilots, ops copilots, research pods, complex routing.</span></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="callout">
+      <strong>Note:</strong> Agents vary in levels of complexity and capabilities depending on your need.
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- ── Workflows ── -->
+<section id="workflows">
+  <div class="wrapper">
+    <span class="section-label">AI Workflows</span>
+    <h2>Execution Maturity Model</h2>
+    <p class="section-intro">Show how execution maturity evolves from single-shot prompts to fully autonomous agents so teams can pick the right operating model.</p>
+
+    <div class="workflow-cards">
+      <div class="workflow-card">
+        <img class="workflow-img" src="../../assets/other/non-agentic-workflow.png" alt="Non-agentic workflow diagram" loading="lazy" />
+        <div class="workflow-body">
+          <div class="when">Non-Agentic</div>
+          <h3>Non-Agentic Workflow</h3>
+          <p>A one-off response or lightweight generation with no memory or tool usage. Think of it as querying a smart autocomplete. <strong>Example:</strong> Asking ChatGPT a single question and pasting the reply into your doc.</p>
+        </div>
+      </div>
+      <div class="workflow-card">
+        <img class="workflow-img" src="../../assets/other/agentic-workflow.png" alt="Agentic workflow diagram" loading="lazy" />
+        <div class="workflow-body">
+          <div class="when">Agentic</div>
+          <h3>Agentic Workflow</h3>
+          <p>A co-pilot that iterates with you, calls tools, or keeps short-lived context — IDE copilots, spreadsheet helpers, etc. <strong>Example:</strong> GitHub Copilot suggesting code while you type.</p>
+        </div>
+      </div>
+      <div class="workflow-card">
+        <img class="workflow-img" src="../../assets/other/ai-agent.png" alt="AI agent workflow diagram" loading="lazy" />
+        <div class="workflow-body">
+          <div class="when">Fully Autonomous</div>
+          <h3>AI Agents</h3>
+          <p>Hand over the goal and let the system decide the plan, tools, and escalation path. <strong>Example:</strong> An AI executive assistant that reschedules meetings without step-by-step prompts.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- ── Build Guide ── -->
+<section id="build">
+  <div class="wrapper">
+    <span class="section-label">Build Guide</span>
+    <h2>Building an AI Agent</h2>
+    <p class="section-intro">A copy-ready recipe for shipping production-grade agents that blend prompts, tools, and evaluations.</p>
+
+    <img src="../../assets/other/building-ai-agent.png" alt="Seven-step workflow for building an AI agent" style="width:100%; border-radius:var(--radius); border:1px solid var(--border); margin-bottom:36px;" loading="lazy" />
+
+    <div class="steps">
+      <div class="step">
+        <div class="step-num">1</div>
+        <div>
+          <h3>System Prompt — Goals · Role · Instructions</h3>
+          <ul>
+            <li>Capture the business goal, the agent's voice, and constraint lists inside a locked system prompt.</li>
+            <li>Mirror Persona/Role patterns from this repo so the assistant understands scope, prohibited actions, and escalation paths.</li>
+            <li>Version prompts in source control and add inline TODOs for future guardrails.</li>
+          </ul>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">2</div>
+        <div>
+          <h3>LLM — Base Model, Parameters</h3>
+          <ul>
+            <li>Choose the base model (e.g., <code>openai:gpt-5</code>) and reason through cost, latency, and context window tradeoffs.</li>
+            <li>Fix deterministic parameters (temperature, top_p, max_tokens) for repeatable behavior, then expose overrides through orchestration.</li>
+            <li>Document fallback or cascade strategies if the primary provider rate-limits.</li>
+          </ul>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">3</div>
+        <div>
+          <h3>Tools — Local · API · MCP Server · Agent as a Tool</h3>
+          <ul>
+            <li>Start with native function calls (math, code execution) before wiring external APIs.</li>
+            <li>Register shared tools (search, RAG, CRMs) via Model Context Protocol servers so every agent reuses the same manifests.</li>
+            <li>Treat trustworthy agents as callable tools to compose nested workflows.</li>
+          </ul>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">4</div>
+        <div>
+          <h3>Memory — Episodic · Working · Vector DB · SQL · File Store</h3>
+          <ul>
+            <li><strong>Episodic:</strong> store per-user transcripts for short-lived recall.</li>
+            <li><strong>Working memory:</strong> chunk current task artifacts (draft docs, task lists) inside the conversation window.</li>
+            <li><strong>Long-term:</strong> persist embeddings in a vector database, structured facts in SQL, and large binaries in an object/file store; set retention rules up front.</li>
+          </ul>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">5</div>
+        <div>
+          <h3>Orchestration — Routes · Triggers · Params · Queues · Agent-to-Agent</h3>
+          <ul>
+            <li>Define routing logic (state machines, LangGraph DAGs) that decides when each tool or sub-agent fires.</li>
+            <li>Expose typed parameters so triggers (webhooks, cron, human approvals) can launch runs safely.</li>
+            <li>Use queues or event buses for parallel tool calls and agent-to-agent collaboration.</li>
+          </ul>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">6</div>
+        <div>
+          <h3>UI — Interface</h3>
+          <ul>
+            <li>Ship the smallest possible UX (CLI, chat widget, workflow form) that captures structured inputs and displays streaming outputs.</li>
+            <li>Log every interaction with trace IDs so support teams can replay context.</li>
+            <li>Offer inline feedback toggles that write directly into your evaluation store.</li>
+          </ul>
+        </div>
+      </div>
+      <div class="step">
+        <div class="step-num">7</div>
+        <div>
+          <h3>AI Evals — Analyze · Measure · Improve</h3>
+          <ul>
+            <li>Add promptfoo or custom regression suites that assert structure (<code>contain-json</code>) plus domain-specific KPIs (accuracy, safety, tone).</li>
+            <li>Review eval deltas before deployments and attach dashboards to orchestrator metrics (latency, tool failures).</li>
+            <li>Feed eval learnings back into prompt and tool updates to close the loop.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div style="margin-top:36px;">
+      <h3 style="margin-bottom:16px; font-size:1rem;">Quick-Start Checks</h3>
+      <div class="checks">
+        <div class="check-item">Clarify success metrics (response time, accuracy, compliance) before coding.</div>
+        <div class="check-item">Mock the agent run with a single workflow recording; confirm each message and tool output matches expectations.</div>
+        <div class="check-item">Keep every dependency swappable (models, MCP servers, vector stores) so the stack remains portable.</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- ── Frameworks ── -->
+<section id="frameworks">
+  <div class="wrapper">
+    <span class="section-label">Frameworks</span>
+    <h2>Common Agentic Frameworks</h2>
+    <p class="section-intro">A comparison of major no-code and code-first agent frameworks by model support, MCP compatibility, tools, and orchestration style.</p>
+
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>No-code</th>
+            <th>Framework</th>
+            <th>LLM</th>
+            <th>MCP</th>
+            <th>Tools</th>
+            <th>Agents Orchestration</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><span class="check-no">✗</span></td>
+            <td><a href="https://platform.openai.com/docs/guides/agents" target="_blank" rel="noreferrer">OpenAI Agents API</a></td>
+            <td>OpenAI</td>
+            <td>Remote</td>
+            <td>Predefined (web, file/code)</td>
+            <td>Threads</td>
+          </tr>
+          <tr>
+            <td><span class="check-no">✗</span></td>
+            <td><a href="https://cloud.google.com/products/agent-builder?hl=en" target="_blank" rel="noreferrer">Google Vertex AI</a></td>
+            <td>*</td>
+            <td>Remote</td>
+            <td>Predefined (search, vision, etc.)</td>
+            <td>Flow-based, native A2A</td>
+          </tr>
+          <tr>
+            <td><span class="check-no">✗</span></td>
+            <td><a href="https://www.anthropic.com/engineering/building-agents-with-the-claude-agent-sdk" target="_blank" rel="noreferrer">Anthropic Agents API</a></td>
+            <td>*</td>
+            <td>Remote</td>
+            <td>Predefined (web, file/code)</td>
+            <td>Tool-calling only</td>
+          </tr>
+          <tr>
+            <td><span class="check-no">✗</span></td>
+            <td><a href="https://microsoft.github.io/autogen/stable//index.html" target="_blank" rel="noreferrer">Microsoft AutoGen</a></td>
+            <td>*</td>
+            <td>None</td>
+            <td>Predefined (REPL, code)</td>
+            <td>Programmatic chaining</td>
+          </tr>
+          <tr>
+            <td><span class="check-yes">✓</span></td>
+            <td><a href="https://microsoft.github.io/autogen/dev//user-guide/autogenstudio-user-guide/index.html" target="_blank" rel="noreferrer">Autogen Studio</a></td>
+            <td>*</td>
+            <td>None</td>
+            <td>Predefined</td>
+            <td>Visual agent chaining</td>
+          </tr>
+          <tr>
+            <td><span class="check-no">✗</span></td>
+            <td><a href="https://docs.langchain.com/oss/python/langgraph/studio" target="_blank" rel="noreferrer">LangGraph</a></td>
+            <td>Local, Remote</td>
+            <td>Local, Remote</td>
+            <td>LangChain Functions</td>
+            <td>Graph (DAG)-based flow</td>
+          </tr>
+          <tr>
+            <td><span class="check-no">✗</span></td>
+            <td><a href="https://docs.langchain.com/oss/python/langgraph/studio" target="_blank" rel="noreferrer">LangChain</a></td>
+            <td>Local, Remote</td>
+            <td>Remote</td>
+            <td>Functions (custom-defined)</td>
+            <td>Manual (chains/agents)</td>
+          </tr>
+          <tr>
+            <td><span class="check-no">✗</span></td>
+            <td><a href="https://docs.crewai.com/introduction" target="_blank" rel="noreferrer">CrewAI</a></td>
+            <td>Local, Remote</td>
+            <td>Remote</td>
+            <td>Predefined, 40+ integrations</td>
+            <td>Flow- &amp; role-based</td>
+          </tr>
+          <tr>
+            <td><span class="check-yes">✓</span></td>
+            <td><a href="https://n8n.io/" target="_blank" rel="noreferrer">n8n</a></td>
+            <td>Local, Remote</td>
+            <td>Remote</td>
+            <td>Predefined, 100+ integrations</td>
+            <td>Workflows, sub-workflows</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
+<div class="section-divider"></div>
+
+<!-- ── References ── -->
+<section id="references">
+  <div class="wrapper">
+    <span class="section-label">References</span>
+    <h2>Sources &amp; Further Reading</h2>
+    <p class="section-intro">Academic papers, framework documentation, and guides referenced in this overview.</p>
+
+    <div class="refs">
+      <div class="ref-item"><a href="https://arxiv.org/abs/2201.11903" target="_blank" rel="noreferrer">Wei et al. – Chain-of-thought prompting elicits reasoning in large language models</a></div>
+      <div class="ref-item"><a href="https://arxiv.org/abs/2302.11382" target="_blank" rel="noreferrer">White – Persona Pattern: Prompt Pattern Catalog</a></div>
+      <div class="ref-item"><a href="https://www.vanderbilt.edu/generative-ai/prompt-patterns/" target="_blank" rel="noreferrer">Vanderbilt University – Prompt Patterns collection</a></div>
+      <div class="ref-item"><a href="https://www.vanderbilt.edu/datascience/2023/08/29/new-course-chatgpt-advanced-data-analysis-by-dr-jules-white-associate-professor-of-computer-science/" target="_blank" rel="noreferrer">White – ChatGPT Advanced Data Analysis course announcement</a></div>
+      <div class="ref-item"><a href="https://link.springer.com/chapter/10.1007/978-3-031-61154-4_8" target="_blank" rel="noreferrer">Herda et al. – LLM-Based Agents for Automating the Enhancement of User Story Quality</a></div>
+      <div class="ref-item"><a href="https://cloud.google.com/discover/what-are-ai-agents" target="_blank" rel="noreferrer">Google Cloud – What are AI agents?</a></div>
+      <div class="ref-item"><a href="https://www.microsoft.com/insidetrack/blog/how-our-employees-are-extending-enterprise-ai-with-custom-retrieval-agents/" target="_blank" rel="noreferrer">Microsoft Inside Track – How our employees are extending enterprise AI with custom retrieval agents</a></div>
+      <div class="ref-item"><a href="https://platform.openai.com/docs/guides/agents" target="_blank" rel="noreferrer">OpenAI – Agents API guide</a></div>
+      <div class="ref-item"><a href="https://cloud.google.com/products/agent-builder?hl=en" target="_blank" rel="noreferrer">Google Cloud – Vertex AI Agent Builder</a></div>
+      <div class="ref-item"><a href="https://www.anthropic.com/engineering/building-agents-with-the-claude-agent-sdk" target="_blank" rel="noreferrer">Anthropic – Building agents with the Claude Agent SDK</a></div>
+      <div class="ref-item"><a href="https://microsoft.github.io/autogen/stable//index.html" target="_blank" rel="noreferrer">Microsoft – AutoGen documentation</a></div>
+      <div class="ref-item"><a href="https://docs.crewai.com/introduction" target="_blank" rel="noreferrer">CrewAI – Framework documentation</a></div>
+      <div class="ref-item"><a href="https://n8n.io/" target="_blank" rel="noreferrer">n8n – Official site</a></div>
+    </div>
+  </div>
+</section>
+
+<!-- ── Footer ── -->
+<footer>
+  <p>MIT (code) / CC BY 4.0 (docs) — <a href="https://github.com/TomasHer/prompting-blueprints" target="_blank" rel="noreferrer">TomasHer/prompting-blueprints</a> · Part of <em>Prompting Blueprints</em> by <a href="https://www.linkedin.com/in/herdatom/" target="_blank" rel="noreferrer">Tomas Herda</a></p>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
Converts 02-ai-agents/01-foundations/ai-agents-overview.md into a
self-contained, visually rich HTML page with dark-theme glassmorphism
design matching the project's existing aesthetic (ai-toolkit.html).
Includes hero, timeline, architecture layers, agent type cards,
workflow cards with images, 7-step build guide, frameworks table,
and references.

https://claude.ai/code/session_0163Mmu8vZrht76rSXBicpP7