### PR TITLE
Add CLAUDE.md design tutorial and cross-reference it in relevant files

### DIFF
--- a/02-ai-agents/03-context-and-memory/agent-context-window-performance.md
+++ b/02-ai-agents/03-context-and-memory/agent-context-window-performance.md
@@ -169,6 +169,7 @@ The goal is not to fill the context window. It is to keep each context window sm
 - [DAIR.AI Academy — Does AGENTS.md Actually Help Coding Agents?](https://academy.dair.ai/blog/agents-md-evaluation)
 - [InfoQ — New Research Reassesses the Value of AGENTS.md Files for AI Coding](https://www.infoq.com/news/2026/03/agents-context-file-value-review/)
 - [OpenAI — GPT-5.4 MRCR v2 8-needle eval results (March 5, 2026)](https://openai.com)
+- [How to Design a CLAUDE.md That Actually Works](../../05-tools/claude-md-design-tutorial.md)
 - [02-ai-agents/context-engineering.md](./context-engineering.md)
 - [02-ai-agents/ai-agents-overview.md](./ai-agents-overview.md)
 - [02-ai-agents/anatomy-of-a-skill.md](./anatomy-of-a-skill.md)

--- a/05-tools/claude-code-certification-guide.md
+++ b/05-tools/claude-code-certification-guide.md
@@ -119,6 +119,7 @@ Evaluate this prompt for schema reliability. Return:
 - Prefer answers with explicit guardrails, deterministic outputs, and clear ownership boundaries.
 
 ## Related pages
+- [How to Design a CLAUDE.md That Actually Works](./claude-md-design-tutorial.md)
 - [Claude Agent Skills Playbook](../02-ai-agents/claude-agent-skills.md)
 - [Model Context Protocol (MCP) Quick Start](../02-ai-agents/mcp-guide.md)
 - [Claude Code Tool Guide](./claude-code-tool-guide.md)

--- a/05-tools/claude-code-cheatsheet-tutorial.md
+++ b/05-tools/claude-code-cheatsheet-tutorial.md
@@ -207,3 +207,4 @@ REQUEST: Provide a short plan, then implement.
 - Claude Code official website: <https://claude.com/product/claude-code>
 - [Everything Claude Code (GitHub)](https://github.com/affaan-m/everything-claude-code)
 - [Claude Code Project Structure Tutorial](./claude-code-project-structure-tutorial.md)
+- [How to Design a CLAUDE.md That Actually Works](./claude-md-design-tutorial.md) — Dedicated guide covering scopes, the WHAT/WHY/HOW framework, vague-vs-precise rules, and 5 rules for effective CLAUDE.md files

--- a/05-tools/claude-code-cheatsheet-v2.md
+++ b/05-tools/claude-code-cheatsheet-v2.md
@@ -388,6 +388,7 @@ The following pages from this repository are relevant to this cheat sheet:
 - [Claude Code Tool Guide](./claude-code-tool-guide.md) — Comprehensive guide to Claude Code capabilities and usage
 - [Claude Code Cheatsheet Tutorial](./claude-code-cheatsheet-tutorial.md) — Earlier cheatsheet reference (pre-v2.81)
 - [Claude Code Project Structure Tutorial](./claude-code-project-structure-tutorial.md) — Best practices for organizing projects in Claude Code
+- [How to Design a CLAUDE.md That Actually Works](./claude-md-design-tutorial.md) — Scopes, WHAT/WHY/HOW framework, and 5 rules for effective CLAUDE.md files
 - [Claude Code Certification Guide](./claude-code-certification-guide.md) — Certification path for Claude Code proficiency
 - [Claude Code NotebookLM Integration Tutorial](./claude-code-notebooklm-integration-tutorial.md) — Guide for integrating Claude Code with NotebookLM
 - [Claude.ai vs Code vs Cowork](./claude-ai-vs-code-vs-cowork.md) — Comparison of Claude.ai, Claude Code, and Cowork tools

--- a/05-tools/claude-code-project-structure-tutorial.md
+++ b/05-tools/claude-code-project-structure-tutorial.md
@@ -310,6 +310,7 @@ Configure via `.mcp.json`:
 ---
 
 ## 9. Related Resources
+- **[How to Design a CLAUDE.md That Actually Works](./claude-md-design-tutorial.md)** — Dedicated guide to scopes, the WHAT/WHY/HOW framework, and the 5 rules for effective CLAUDE.md files.
 - **[Claude Agent Skills Playbook](../02-ai-agents/claude-agent-skills.md)** — Dive deeper into building reusable workflows.
 - **[Claude AI vs Claude Code vs Claude Cowork](./claude-ai-vs-code-vs-cowork.md)** — Understand which tool fits your specific use case.
 - **[Claude Code Tool Guide](./claude-code-tool-guide.md)** — Explore additional automation commands and configurations.

--- a/05-tools/claude-md-design-tutorial.md
+++ b/05-tools/claude-md-design-tutorial.md
@@ -1,0 +1,182 @@
+---
+title: "How to Design a CLAUDE.md That Actually Works"
+tags: ["tools", "claude-code"]
+last_updated: "2026-05-13"
+---
+
+# How to Design a CLAUDE.md That Actually Works
+
+The architecture behind your AI agent's memory — scopes, frameworks, and the rules that separate chaos from clarity.
+
+> *"CLAUDE.md is not a README for humans. It's onboarding docs for your AI teammate."*
+
+---
+
+## Why CLAUDE.md Matters
+
+CLAUDE.md is Claude Code's **persistent memory** — the one file that survives context compaction and is loaded automatically at the start of every session. Unlike a README written for human readers, CLAUDE.md is written for an AI teammate: it encodes the non-obvious rules, constraints, and workflows that Claude cannot infer from the codebase alone.
+
+Research from ETH Zurich (arXiv 2602.11988) confirms that **developer-written, minimal context files improve task success rates by an average of +4 percentage points**, while bloated or LLM-generated files reduce success and raise inference costs by 19–23%. Design matters.
+
+---
+
+## 01 — The 3 Scopes
+
+CLAUDE.md is not a single file — it is a hierarchy of files, each scoped to a different level:
+
+| Scope | Path | Purpose |
+|---|---|---|
+| **Global** | `~/.claude/CLAUDE.md` | Personal defaults across all projects. Coding style, patterns, universal rules. |
+| **Project** | `./CLAUDE.md` | Project-specific rules. Build commands, test setup, team conventions. |
+| **Folder** | `./src/CLAUDE.md` | Module-level overrides. Scoped context for APIs, components, utils. |
+
+Resolution order: **Global → Project → Folder** — the last scope wins on conflicts.
+
+Use the global file for personal preferences that apply everywhere. Use the project file for team-shared conventions checked into git. Add folder-level files only when a module has genuinely different rules from the rest of the project (for example, a `src/api/CLAUDE.md` that enforces strict OpenAPI contract rules).
+
+---
+
+## 02 — The WHAT / WHY / HOW Framework
+
+Structure your CLAUDE.md around three questions:
+
+### WHAT — Give Context
+
+What is this project and how is it built?
+
+- Project name & purpose
+- Tech stack & versions
+- Repository structure map
+- Key dependencies
+- Environment variables
+
+### WHY — Set Principles
+
+Why are things done this way?
+
+- Architecture decisions
+- Code style & lint rules
+- Naming conventions
+- Anti-patterns to avoid
+- Error handling approach
+
+### HOW — Define Workflows
+
+How does a developer (or agent) actually work on this project?
+
+- Build: `npm run build`
+- Test: `npm test`
+- Lint: `eslint . --fix`
+- Commit format
+- Deploy & CI/CD steps
+
+A complete CLAUDE.md answers all three questions. Most files only cover WHAT and HOW — the WHY section is the most commonly omitted and the most valuable for preventing agent drift.
+
+---
+
+## 03 — Example CLAUDE.md
+
+```markdown
+# Project: Pixels Connect
+
+## Tech Stack
+Next.js 14, Supabase, Tailwind CSS
+
+## Build & Test
+- Build: `npm run build`
+- Test: `npm test -- --watch`
+
+## Code Style
+- Variables: camelCase
+- Components: PascalCase
+- Min 80% coverage for `utils/`
+
+## Architecture Rules
+- App Router only — no `pages/` directory
+- Server Components by default
+- All DB access via Supabase client, never raw SQL
+```
+
+---
+
+## 04 — Be Specific: Vague vs Precise
+
+Vague instructions produce inconsistent results. Claude Code follows instructions literally, so precision is the difference between enforced rules and ignored suggestions.
+
+| Vague | Precise |
+|---|---|
+| ❌ "Write clean code" | ✅ "Use camelCase for variables, PascalCase for components" |
+| ❌ "Test everything" | ✅ "`npm test -- --watch`, min 80% coverage for `utils/`" |
+| ❌ "Follow security best practices" | ✅ "MUST NOT store card numbers; use Stripe token references only" |
+| ❌ "Use a database" | ✅ "MUST use PostgreSQL for all persistent state" |
+
+For architecture constraints that must never be violated, use RFC 2119 keywords (`MUST`, `SHOULD`, `MAY`). These signal the severity of each rule to the agent and have a track record of improving compliance in instruction-following tasks.
+
+---
+
+## 05 — 5 Rules That Make It Work
+
+### 1. Run `/init` First
+
+Let Claude scaffold the baseline from the existing codebase, then curate the result. Starting from `/init` output is faster and more accurate than writing from scratch — Claude reads your actual project structure rather than guessing.
+
+### 2. Stay Under 500 Lines
+
+Too long = ignored content. Research confirms that shorter, more targeted files correlate with better agent performance. Keep the file focused: if a section applies only to one module, move it to a folder-level CLAUDE.md instead.
+
+### 3. Use Hooks for 100% Enforcement
+
+CLAUDE.md instructions are followed approximately 70% of the time — they are guidance, not guarantees. For rules that must be absolute (no secrets in commits, always run lint before push), use Claude Code Hooks. Hooks execute deterministically and cannot be reasoned around.
+
+### 4. Update It Monthly
+
+CLAUDE.md is a living document. Evolve it as your architecture changes. Schedule a monthly review to remove stale rules, add newly discovered conventions, and update build commands when tooling changes.
+
+### 5. Reference Files, Don't Duplicate
+
+Point to `package.json`, `tsconfig.json`, `.eslintrc` — don't copy their contents into CLAUDE.md. Duplication creates drift: when the source file changes, CLAUDE.md becomes stale and gives Claude contradictory information.
+
+---
+
+## What to Include vs. Omit
+
+Based on ETH Zurich research (arXiv 2602.11988), agent performance improves when CLAUDE.md contains only information Claude cannot infer from the codebase itself.
+
+| Include | Omit |
+|---|---|
+| Non-obvious build or test commands | General best practices the model already knows |
+| Custom test invocation flags | Information already present in the README |
+| Non-standard environment setup | Content that duplicates `package.json` or config files |
+| Architecture constraints that must be enforced | Generic style advice (use precise rules instead) |
+| Anti-patterns specific to this codebase | LLM-generated boilerplate |
+
+**Never use LLM-generated CLAUDE.md files as-is.** They restate README content, inflate inference costs by 19–23%, and reduce task success rates by 2–3 percentage points on average.
+
+---
+
+## Quick-Start Checklist
+
+- [ ] Run `/init` to generate a baseline from the existing codebase
+- [ ] Trim to under 500 lines, removing anything inferable from the code
+- [ ] Structure content using the WHAT / WHY / HOW sections
+- [ ] Replace vague instructions with precise, measurable rules
+- [ ] Add folder-level CLAUDE.md files for modules with distinct rules
+- [ ] Use Claude Code Hooks for rules that must be enforced 100% of the time
+- [ ] Reference config files by path rather than duplicating their contents
+- [ ] Schedule a monthly review as part of your team's development process
+
+---
+
+## Related Resources
+
+- **[Claude Code Project Structure Tutorial](./claude-code-project-structure-tutorial.md)** — Memory hierarchy, skill structure, and the 4-layer architecture.
+- **[Claude Code Cheat Sheet v2.81](./claude-code-cheatsheet-v2.md)** — Quick reference for `/init`, `/memory`, and all CLAUDE.md-related commands.
+- **[Spec-Driven Development Tutorial](./spec-driven-development-tutorial.md)** — Using CLAUDE.md as a lightweight spec with RFC 2119 keywords.
+- **[Agent Context Window Performance](../02-ai-agents/03-context-and-memory/agent-context-window-performance.md)** — Research-backed guidance on why context file size and quality matter.
+- **[Claude Code Certification Guide](./claude-code-certification-guide.md)** — Exam preparation covering CLAUDE.md hierarchies and path-specific overrides.
+
+## References
+
+- [arXiv 2602.11988 — Evaluating AGENTS.md: Are Repository-Level Context Files Helpful for Coding Agents?](https://arxiv.org/abs/2602.11988)
+- Brij Kishore Pandey — Claude Code Architecture Guide: How to Design a CLAUDE.md That Actually Works (2026)
+- Claude Code documentation: <https://docs.anthropic.com/en/docs/claude-code/overview>

--- a/05-tools/spec-driven-development-tutorial.md
+++ b/05-tools/spec-driven-development-tutorial.md
@@ -314,5 +314,6 @@ The human reviews the agent's execution log, confirms the plan matches the Spec,
 - Strands Agent SOP repository: https://github.com/strands-agents/agent-sop/tree/main
 - GitHub spec-kit: https://github.com/github/spec-kit
 - Claude Code CLI overview: https://docs.anthropic.com/en/docs/claude-code/overview
+- [Prompting Blueprints — How to Design a CLAUDE.md That Actually Works](./claude-md-design-tutorial.md)
 - [Prompting Blueprints — AI Coding Spectrum](../02-ai-agents/ai-coding-spectrum.md)
 - [Prompting Blueprints — Vibe Coding Tech Stack](../04-guides/vibe-coding-tech-stack.md)


### PR DESCRIPTION
Creates 05-tools/claude-md-design-tutorial.md covering the 3 scopes,
WHAT/WHY/HOW framework, vague-vs-precise guidance, 5 enforcement rules,
and research-backed include/omit guidance — consolidating CLAUDE.md design
content that was previously scattered across multiple tutorials.

Adds a reference link to the new tutorial in:
- claude-code-project-structure-tutorial.md
- claude-code-cheatsheet-v2.md
- claude-code-cheatsheet-tutorial.md
- spec-driven-development-tutorial.md
- claude-code-certification-guide.md
- agent-context-window-performance.md

https://claude.ai/code/session_01CczghdKfgCYsrmvT6sMxV1