### PR TITLE
feat(guides): add Codex TDD workflow and Skills guide, update prompting guide

### DIFF
--- a/04-guides/codex-agent-prompting-guide.md
+++ b/04-guides/codex-agent-prompting-guide.md
@@ -26,7 +26,7 @@ Goal: <what you want shipped>
 Scope: <files/dirs to edit + files to avoid>
 Context: <symptoms, logs, stack traces, upstream tickets, related PRs>
 Constraints: <style guides, approvals, rollout rules, security limits>
-Tests/Checks: <commands + expected outcomes>
+Done when / Tests: <runnable command + expected outcome, e.g. "pytest exits 0, no test files modified">
 Tools/Notes: <specific commands to prefer/avoid, feature flags, feature toggles>
 
 Plan first, then execute. Narrate major decisions. Ask before risky actions.
@@ -50,6 +50,14 @@ OUTPUT FORMAT: Markdown with sections → Plan, Changes, Tests, Next steps.
 - `subdir/AGENTS.override.md`
   - Team-specific overrides: service-specific tests, forbidden commands, data-handling rules.
 
+## Running tasks in parallel
+Codex can handle multiple independent tasks simultaneously. When work items don't share files or state, submit them in separate sessions at the same time rather than sequentially.
+
+- Open one Codex session per independent task (e.g., fix auth bug / add search endpoint / update docs).
+- Each session gets its own branch; merge when both are green.
+- Avoid parallel sessions on the same files — merge conflicts cost more than the time saved.
+- Use a parent task to coordinate: "Run sessions A, B, and C in parallel; do D only after all three merge."
+
 ## Validation and troubleshooting
 - Run `codex --ask-for-approval never "Summarize the current instructions."` from the repo root to confirm which files Codex loaded and in what order.
 - If guidance is missing, check for higher-level `AGENTS.override.md` files or bump `project_doc_max_bytes`.
@@ -59,3 +67,4 @@ OUTPUT FORMAT: Markdown with sections → Plan, Changes, Tests, Next steps.
 - https://developers.openai.com/codex/prompting
 - https://developers.openai.com/codex/guides/agents-md
 - https://agents.md
+- [Codex TDD Workflow and Skills Guide](./codex-tdd-and-skills.md)

--- a/04-guides/codex-tdd-and-skills.md
+++ b/04-guides/codex-tdd-and-skills.md
@@ -1,0 +1,244 @@
+---
+title: "Codex TDD Workflow and Skills Guide"
+tags: ["guides", "codex-agent", "testing", "skills"]
+last_updated: "2026-05-21"
+---
+
+# Codex TDD Workflow and Skills Guide
+
+## Intent
+- Run reliable, reviewable Codex sessions by anchoring implementation to failing tests.
+- Package recurring workflows as Codex Skills so every team member (and every agent) executes them the same way.
+
+---
+
+## Part 1 — Test-Driven Codex Workflow
+
+### Why tests first
+Without tests, Codex verifies its own work using internal judgment. A failing test is an unambiguous, machine-readable exit condition: Codex knows exactly when it is done, and so do you. The red-to-green cycle also gives you a safe rollback point — if Codex goes off-track, you revert to the committed failing-test checkpoint and try a tighter prompt.
+
+### The four-step loop
+
+```
+1. Write failing test(s)   →   commit as checkpoint
+2. Prompt Codex to implement   (do NOT let it modify tests)
+3. Confirm green           →   review diff
+4. Refactor if needed      →   re-run tests
+```
+
+#### Step 1 — Write and commit failing tests
+Write the tests yourself (or ask Codex to write tests only, with no implementation). Confirm they all fail before any implementation starts.
+
+```bash
+# Confirm red
+pytest tests/test_payments.py        # or: npm test, go test ./..., etc.
+git add tests/
+git commit -m "test: add failing tests for webhook retry logic"
+```
+
+The commit is your checkpoint. If the session goes wrong, `git checkout HEAD` returns you here.
+
+#### Step 2 — Prompt Codex to implement
+Use the standard context template and add an explicit constraint against test modification:
+
+```text
+Goal: Make all tests in tests/test_payments.py pass.
+Scope: src/payments/webhooks.py — do NOT edit tests/.
+Context: Tests were added in the previous commit; they cover retry back-off and idempotency key handling.
+Constraints: Follow AGENTS.md style. No new dependencies without discussion.
+Done when: pytest tests/test_payments.py exits 0, no test files modified.
+Tools/Notes: Use pnpm, not npm. Run linter with ruff check src/.
+```
+
+The `Done when` line is the exit condition. Codex stops when it is satisfied, not when it runs out of ideas.
+
+#### Step 3 — Confirm green and review
+Before accepting the task:
+
+```bash
+pytest tests/test_payments.py        # must be green
+git diff HEAD~1 -- tests/            # must show zero changes to test files
+ruff check src/                      # linter clean
+```
+
+Review the diff as you would a human PR. If Codex quietly modified a test to make it pass, reject the session and tighten the `Scope` constraint.
+
+#### Step 4 — Refactor with confidence
+Because the tests are intact, you can ask Codex to clean up:
+
+```text
+Goal: Refactor the implementation in src/payments/webhooks.py for readability.
+Scope: src/payments/webhooks.py only.
+Done when: pytest tests/test_payments.py still exits 0 and the file is < 120 lines.
+```
+
+### Anti-patterns to avoid
+
+| Anti-pattern | Why it hurts | Fix |
+|---|---|---|
+| No test checkpoint commit | No safe rollback point | Always commit before prompting for implementation |
+| Letting Codex write tests and implementation together | Codex can write tests that match its own bugs | Separate the two steps |
+| Vague `Done when` (e.g., "looks good") | Codex keeps iterating or stops too early | Use a runnable command as the exit condition |
+| Skipping diff review on test files | Codex may modify assertions to make them pass | Always run `git diff HEAD~1 -- tests/` |
+
+---
+
+## Part 2 — Codex Skills
+
+### What a Skill is
+A Codex Skill packages a reusable workflow — instructions, resource references, and optional setup scripts — into a named unit that Codex loads on demand. Instead of re-explaining a recurring procedure in every prompt, you define it once and invoke it by name.
+
+**Skills are ideal for:**
+- Release checklists (tag, changelog, publish)
+- Code review workflows (lint, test, summarise diff, post comment)
+- Database migration sequences
+- Recurring content generation pipelines (e.g., changelog → newsletter)
+
+### Skill anatomy
+
+```
+~/.codex/skills/
+└── <skill-name>/
+    ├── skill.md          # Human-readable instructions Codex follows
+    ├── setup.sh          # Optional: install deps, set env vars (runs once per session)
+    └── resources/        # Optional: reference files, templates, schema examples
+        └── template.md
+```
+
+`skill.md` is the core. Write it like a concise AGENTS.md section: what the skill does, step-by-step instructions, and what "done" looks like.
+
+### Writing skill.md
+
+```markdown
+# Skill: webhook-release
+
+## Purpose
+Cut a release for the payments webhook service: bump version, update changelog, tag, push.
+
+## Steps
+1. Run `pytest` — abort if any test fails.
+2. Bump the patch version in `pyproject.toml` using `bump2version patch`.
+3. Update `CHANGELOG.md` — move items from **Unreleased** to the new version heading.
+4. Commit: `chore(release): bump to <new-version>`.
+5. Tag: `git tag v<new-version>`.
+6. Push branch and tag: `git push && git push --tags`.
+
+## Done when
+- `git tag` lists the new version.
+- `CHANGELOG.md` has no items under **Unreleased**.
+- CI passes (check with `gh run watch`).
+
+## Abort conditions
+- Any test failure in step 1.
+- `pyproject.toml` version already matches the target.
+```
+
+### Invoking a Skill
+
+In the Codex chat interface, prefix the skill name with `/`:
+
+```
+/webhook-release
+```
+
+Or compose it with additional context:
+
+```
+/webhook-release — but skip the git push, I'll do that manually after review.
+```
+
+### Layering Skills with AGENTS.md
+
+Register frequently-used skills in your project `AGENTS.md` so Codex knows they exist without being told:
+
+```markdown
+## Available Skills
+- `/webhook-release` — cut a patch release for the payments service.
+- `/pr-review` — lint, test, summarise diff, and post a review comment draft.
+- `/changelog-to-newsletter` — convert the latest CHANGELOG section to a newsletter draft.
+```
+
+This turns Skills into a team API: new contributors see what's available, and Codex can suggest the right skill when a task matches.
+
+### Sharing Skills across a team
+Store shared skills in the repo under `.codex/skills/` and commit them. Each developer's local `~/.codex/skills/` holds personal overrides; the repo-level directory holds canonical team workflows.
+
+```
+repo-root/
+└── .codex/
+    └── skills/
+        ├── pr-review/
+        │   └── skill.md
+        └── webhook-release/
+            └── skill.md
+```
+
+Point Codex at the repo-level directory by adding to `~/.codex/config.toml`:
+
+```toml
+extra_skills_dirs = [".codex/skills"]
+```
+
+---
+
+## Part 3 — Combining TDD and Skills
+
+The TDD loop and Skills compose naturally. Define a skill that encodes your team's full red-green cycle so every developer runs it identically:
+
+```markdown
+# Skill: tdd-implement
+
+## Purpose
+Implement a feature using the TDD red-green-refactor loop.
+
+## Pre-conditions
+- Failing tests already written and committed.
+
+## Steps
+1. Read the most recent commit message to understand the feature under test.
+2. Implement only in the `src/` files referenced by the failing tests.
+3. Do NOT modify any file under `tests/`.
+4. Run the test suite: `pytest` (or the command in AGENTS.md).
+5. If green: run linter (`ruff check src/`), then summarise the diff.
+6. If still red after 3 attempts: stop and report the blocker.
+
+## Done when
+- Test suite exits 0.
+- No changes to `tests/` in the diff.
+- Linter clean.
+```
+
+Invoke it after committing your failing tests:
+
+```
+/tdd-implement
+```
+
+---
+
+## Quick-reference checklist
+
+```
+TDD loop
+[ ] Write tests — confirm they fail
+[ ] git commit tests as checkpoint
+[ ] Prompt Codex with explicit Done when and no-test-edit constraint
+[ ] Verify green: pytest / npm test / go test
+[ ] Verify no test file changes: git diff HEAD~1 -- tests/
+[ ] Linter clean
+[ ] Review diff before accepting
+
+Skills
+[ ] Create skill.md with Purpose, Steps, Done when, Abort conditions
+[ ] Add optional setup.sh for one-time deps
+[ ] Register skill in AGENTS.md ## Available Skills section
+[ ] Commit shared skills under .codex/skills/
+[ ] Add extra_skills_dirs to config.toml
+```
+
+---
+
+## References
+- https://developers.openai.com/codex/learn/best-practices
+- https://developers.openai.com/codex/skills
+- https://developers.openai.com/codex/guides/agents-md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
     - Reasoning vs. Classic LLMs (DE): 04-guides/reasoning-vs-classic-llms-de.md
     - 12 Rules for AI Coding Tools (Senior Engineer Edition): 04-guides/ai-coding-rules-senior-engineers.md
     - Codex Agent Prompting Guide: 04-guides/codex-agent-prompting-guide.md
+    - Codex TDD Workflow and Skills Guide: 04-guides/codex-tdd-and-skills.md
     - Fine-Tune an Open Source LLM with Claude: 04-guides/claude-fine-tune-llm.md
     - FunctionGemma Fine-Tuning + Local Serving (LM Studio): 04-guides/finetune-functiongemma.md
     - Best Model Providers for AI Agents for 2026: 02-ai-agents/models-for-ai-agents-2026.md


### PR DESCRIPTION
- Add 04-guides/codex-tdd-and-skills.md covering the red-green-refactor
  loop with Codex (failing tests as checkpoint, Done-when exit condition,
  no-test-edit constraint) and Codex Skills authoring, invocation, and
  team sharing patterns
- Update codex-agent-prompting-guide.md: rename Tests/Checks field to
  "Done when / Tests" to emphasise acceptance criteria as exit condition,
  add parallel tasking section, link to new guide
- Register new guide in mkdocs.yml

https://claude.ai/code/session_018nkgzu4t72wragMhEzr6jU