### PR TITLE
Fix broken image path in context-engineering tutorial

### DIFF
--- a/02-ai-agents/03-context-and-memory/context-engineering.md
+++ b/02-ai-agents/03-context-and-memory/context-engineering.md
@@ -6,7 +6,7 @@ last_updated: "2026-01-10"
 
 # Context Engineering
 
-![Context engineering overview](../assets/other/context-engineering.PNG)
+![Context engineering overview](../../assets/other/context-engineering.PNG)
 
 Context engineering is the discipline of dynamically managing the entirety of information an AI agent sees. It's about filling the context window with the right information for the next step.
 


### PR DESCRIPTION
The image reference used one level up (../assets/) but the file is two
directories deep, so the correct relative path is ../../assets/.

https://claude.ai/code/session_01E6qBUJptqdSz6dVt4TnwVr