### PR TITLE
feat(conferences): add GAISE 2026 page and reusable conference template

### DIFF
--- a/09-conferences/conference-template.md
+++ b/09-conferences/conference-template.md
@@ -1,0 +1,113 @@
+---
+title: "Conference Notes — Template"
+tags: ["conferences", "template"]
+last_updated: "2026-06-07"
+---
+
+<!--
+REUSABLE CONFERENCE TEMPLATE
+============================
+How to use:
+1. Copy this file to 09-conferences/<event-slug>.md (e.g. gaise-2027.md).
+2. Create an assets folder: assets/conferences/<event-slug>/ and drop photos there.
+3. Update the front-matter (title, tags, last_updated).
+4. Replace every [BRACKETED] placeholder and remove the HTML comments you don't need.
+5. Add a nav entry in mkdocs.yml under the "Conferences" section.
+6. Duplicate the "Session block" for each session you attended.
+
+All image paths assume this file lives in 09-conferences/ (one level deep),
+so assets are reached via ../assets/conferences/<event-slug>/...
+-->
+
+# [EVENT NAME] — [City, Country]
+
+## Event Introduction
+
+**[Full event name]** took place on **[dates]** at **[venue / city]**, hosted by [[organizer]([organizer URL])].
+
+[1–3 sentences: what the event was about, the overarching theme, and why it mattered.]
+
+- **[Day 1 date] — [Theme / Track focus]**
+- **[Day 2 date] — [Theme / Track focus]**
+- **[Day 3 date] — [Theme / Track focus]**
+
+These are my personal notes from the sessions I attended.
+
+**Links:** [Program]([program URL]) · [Speakers]([speakers URL]) · [Organizer]([organizer URL])
+
+<!-- EVENT PHOTO PLACEHOLDER -->
+<img src="../assets/conferences/[event-slug]/event-photo.jpg" alt="[Event name]">
+
+---
+
+## Day 1 — [Date]
+
+### Theme: [Theme] · [Tracks]
+
+### 🎤 Conference Opening
+<!-- Remove this section if the day had no opening. -->
+
+<!-- OPENING PHOTO PLACEHOLDER -->
+<img src="../assets/conferences/[event-slug]/day1-opening.jpg" alt="Conference Opening">
+
+<!-- Short note about the opening. -->
+
+### [Track name] Track
+
+<!-- Session blocks go here. -->
+
+---
+
+## Day 2 — [Date]
+
+### Theme: [Theme] · [Tracks]
+
+### [Track name] Track
+
+<!-- Session blocks go here. -->
+
+---
+
+## Day 3 — [Date]
+
+### Theme: [Theme] · [Tracks]
+
+### [Track name] Track
+
+<!-- Session blocks go here. -->
+
+### 🎤 Conference Closing
+<!-- Remove this section if the day had no closing. -->
+
+<!-- CLOSING PHOTO PLACEHOLDER -->
+<img src="../assets/conferences/[event-slug]/day3-closing.jpg" alt="Conference Closing">
+
+<!-- Short note about the closing. -->
+
+---
+
+## Session block (copy one per session)
+
+```markdown
+#### [Session Title]
+
+<img src="../assets/conferences/[event-slug]/[photo-filename].jpg" alt="[alt text]">
+
+- **Speaker:** [Name, affiliation/role] — [speaker profile link]
+- **Session Type:** [Keynote / Academic talk / Industry talk / Executive panel / Workshop / Lightning talk]
+- **Title:** [Full session title]
+
+**Description**
+
+[2–4 sentences summarizing the session.]
+
+**Interesting slides**
+
+<img src="../assets/conferences/[event-slug]/[slide-filename].jpg" alt="[slide description]">
+
+[Note what made these slides worth capturing.]
+```
+
+---
+
+*Notes by Tomas Herda. Connect on [LinkedIn](https://www.linkedin.com/in/herdatom).*

--- a/09-conferences/gaise-2026.md
+++ b/09-conferences/gaise-2026.md
@@ -1,0 +1,114 @@
+---
+title: "GAISE 2026 — Conference Notes"
+tags: ["conferences", "gaise", "ai", "software-engineering"]
+last_updated: "2026-06-07"
+---
+
+# GAISE 2026 — Tampere, Finland
+
+## Event Introduction
+
+**GAISE 2026 (GAISE Summer School)** took place on **1–3 June 2026** at **Tampere University, Hervanta Campus** (Korkeakoulunkatu 1, 33720 Tampere, Finland), hosted by [GPT-Lab](https://gpt-lab.eu/about-us/our-team/) — a generative-AI research lab founded by Professor Pekka Abrahamsson at Tampere University.
+
+Across three days, the program explored how artificial intelligence is reshaping software engineering and organizations, structured around three thematic areas:
+
+- **Monday, 1 June — Autonomous AI Systems** (Academic & Industry Tracks)
+- **Tuesday, 2 June — AI-Native World** (Academic, Industry & Executive Tracks)
+- **Wednesday, 3 June — Responsible AI Era** (Academic & Industry Tracks)
+
+These are my personal notes from the sessions I attended.
+
+**Links:** [Full program](https://gpt-lab.eu/gaise26-program/) · [Speakers](https://gpt-lab.eu/gaise26-speakers/) · [Organizer: GPT-Lab](https://gpt-lab.eu/about-us/our-team/)
+
+<!-- EVENT PHOTO PLACEHOLDER -->
+<img src="../assets/conferences/gaise-2026/event-photo.jpg" alt="GAISE 2026 — Tampere University">
+
+---
+
+## Day 1 — Monday, 1 June 2026
+
+### Theme: Autonomous AI Systems · Academic & Industry Tracks
+
+### 🎤 Conference Opening
+
+<!-- OPENING PHOTO PLACEHOLDER -->
+<img src="../assets/conferences/gaise-2026/day1-opening.jpg" alt="GAISE 2026 — Conference Opening">
+
+<!-- Add a short note about the opening here. -->
+
+### Academic Track
+
+<!-- Add sessions below using the Session block from "Session Structure" at the bottom of this page. -->
+
+### Industry Track
+
+<!-- Add sessions below. -->
+
+---
+
+## Day 2 — Tuesday, 2 June 2026
+
+### Theme: AI-Native World · Academic, Industry & Executive Tracks
+
+### Academic Track
+
+<!-- Add sessions below. -->
+
+### Industry Track
+
+<!-- Add sessions below. -->
+
+### Executive Track
+
+<!-- Add sessions below. -->
+
+---
+
+## Day 3 — Wednesday, 3 June 2026
+
+### Theme: Responsible AI Era · Academic & Industry Tracks
+
+### Academic Track
+
+<!-- Add sessions below. -->
+
+### Industry Track
+
+<!-- Add sessions below. -->
+
+### 🎤 Conference Closing
+
+<!-- CLOSING PHOTO PLACEHOLDER -->
+<img src="../assets/conferences/gaise-2026/day3-closing.jpg" alt="GAISE 2026 — Conference Closing">
+
+<!-- Add a short note about the closing here. -->
+
+---
+
+## Session Structure (copy this block for each session)
+
+Copy and paste the block below under the relevant day/track, then fill in the details.
+
+```markdown
+#### [Session Title]
+
+<img src="../assets/conferences/gaise-2026/[photo-filename].jpg" alt="[alt text]">
+
+- **Speaker:** [Name, affiliation/role] — [speaker profile link]
+- **Session Type:** [Keynote / Academic talk / Industry talk / Executive panel / Workshop / Lightning talk]
+- **Title:** [Full session title]
+
+**Description**
+
+[2–4 sentences summarizing the session.]
+
+**Interesting slides**
+
+<img src="../assets/conferences/gaise-2026/[slide-filename].jpg" alt="[slide description]">
+
+[Note what made these slides worth capturing.]
+```
+
+---
+
+*Notes by Tomas Herda. Connect on [LinkedIn](https://www.linkedin.com/in/herdatom).*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,6 +118,9 @@ nav:
     - Deep Research Tools Playbook: 07-use-cases-and-research/deep-research.md
     - Summarization Playbook: 07-use-cases-and-research/summarization-tutorial.md
     - AI Video Camera Movements Prompt Library: 07-use-cases-and-research/ai-video-camera-movements-prompt-library.md
+  - Conferences:
+    - GAISE 2026: 09-conferences/gaise-2026.md
+    - Conference Notes Template: 09-conferences/conference-template.md
   - External Sources: external-sources.md
 plugins:
   - search


### PR DESCRIPTION
Add a new 09-conferences section with:
- gaise-2026.md: LinkedIn-ready structure for the GAISE 2026 Summer School (Tampere, 1-3 June 2026), with event intro, photo placeholders, per-day themes and tracks, conference opening/closing photo placeholders, and a copy-paste session block (Photo, Speaker, Session Type, Title, Description, Interesting slides). Session content intentionally left blank to be filled in later.
- conference-template.md: reusable template for future conference notes.
- assets/conferences/gaise-2026/ folder for event photos.
- mkdocs.yml: new "Conferences" nav section linking both pages.