### PR TITLE
Use angle-bracket placeholder for organizer URL in conference template

### DIFF
--- a/09-conferences/conference-template.md
+++ b/09-conferences/conference-template.md
@@ -23,7 +23,7 @@ so assets are reached via ../assets/conferences/<event-slug>/...
 
 ## Event Introduction
 
-**[Full event name]** took place on **[dates]** at **[venue / city]**, hosted by [organizer]([organizer URL]).
+**[Full event name]** took place on **[dates]** at **[venue / city]**, hosted by [organizer](<organizer-url>).
 
 [1–3 sentences: what the event was about, the overarching theme, and why it mattered.]
 


### PR DESCRIPTION
Link destinations containing spaces don't parse as links in CommonMark.
Wrap the placeholder in angle brackets so it renders correctly across
Markdown parsers.

https://claude.ai/code/session_01W1Sk7tvmFieqJ8o3Ta2ATt