### PR TITLE
Add closing section thanking organizers to conference and GAISE templates

### DIFF
--- a/09-conferences/conference-template.md
+++ b/09-conferences/conference-template.md
@@ -105,7 +105,7 @@ Special recognition goes to the main organizers — **[Organizer Name]** and **[
 
 [2–4 sentences summarizing the session.]
 
-**Interesting slides**
+**Interesting slides and observations**
 
 <img src="../assets/conferences/[event-slug]/[slide-filename].jpg" alt="[slide description]">
 

--- a/09-conferences/conference-template.md
+++ b/09-conferences/conference-template.md
@@ -82,7 +82,11 @@ These are my personal notes from the sessions I attended.
 <!-- CLOSING PHOTO PLACEHOLDER -->
 <img src="../assets/conferences/[event-slug]/day3-closing.jpg" alt="Conference Closing">
 
-<!-- Short note about the closing. -->
+A sincere thank you to **[organizing body / lab name]** for hosting and curating an exceptional program.
+
+Special recognition goes to the main organizers — **[Organizer Name]** and **[Organizer Name]** — whose planning and dedication kept everything running seamlessly. Thanks also to all the **volunteers** who made the event experience welcoming and smooth for every attendee.
+
+<!-- Expand with specific highlights or personal thanks as appropriate. -->
 
 ---
 

--- a/09-conferences/gaise-2026.md
+++ b/09-conferences/gaise-2026.md
@@ -105,7 +105,7 @@ Copy and paste the block below under the relevant day/track, then fill in the de
 
 [2–4 sentences summarizing the session.]
 
-**Interesting slides**
+**Interesting slides and observations**
 
 <img src="../assets/conferences/gaise-2026/[slide-filename].jpg" alt="[slide description]">
 

--- a/09-conferences/gaise-2026.md
+++ b/09-conferences/gaise-2026.md
@@ -80,7 +80,11 @@ These are my personal notes from the sessions I attended.
 <!-- CLOSING PHOTO PLACEHOLDER -->
 <img src="../assets/conferences/gaise-2026/day3-closing.jpg" alt="GAISE 2026 — Conference Closing">
 
-<!-- Add a short note about the closing here. -->
+A heartfelt thank you to everyone who made GAISE 2026 possible. The **GPT-Lab team** at Tampere University created an outstanding program that brought together researchers, practitioners, and executives from across the AI and software-engineering community.
+
+Special recognition goes to the main organizers — **Vaishnavi Bankhele** and **Virve Yli-Savola** — whose meticulous planning and tireless effort ensured the event ran smoothly from the first keynote to the final session. Equal thanks to all the **volunteers** who handled registration, logistics, and the countless behind-the-scenes tasks that keep a multi-track conference on track.
+
+Your work gave everyone in the room the space to focus on learning and connecting. Thank you.
 
 ---
 


### PR DESCRIPTION
Adds a thank-you closing block to the Day 3 Conference Closing section in
both the reusable conference template and the GAISE 2026 notes. The GAISE
version names the GPT-Lab team, main organizers Vaishnavi Bankhele and
Virve Yli-Savola, and the volunteers. The generic template uses bracketed
placeholders so future events can fill in their own details.

https://claude.ai/code/session_01WAtiCV17C8iyz7qWo43pUS