### PR TITLE
Replace redistributed third-party documents with official source links

### DIFF
--- a/02-ai-agents/01-foundations/ai-agents-overview.html
+++ b/02-ai-agents/01-foundations/ai-agents-overview.html
@@ -807,7 +807,7 @@
 
 <!-- ── Footer ── -->
 <footer>
-  <p>MIT (code) / CC BY 4.0 (docs) — <a href="https://github.com/TomasHer/prompting-blueprints" target="_blank" rel="noreferrer">TomasHer/prompting-blueprints</a> · Part of <em>Prompting Blueprints</em> by <a href="https://www.linkedin.com/in/herdatom/" target="_blank" rel="noreferrer">Tomas Herda</a></p>
+  <p>MIT (code) / CC BY 4.0 (original docs) — <a href="https://github.com/TomasHer/prompting-blueprints" target="_blank" rel="noreferrer">TomasHer/prompting-blueprints</a> · Part of <em>Prompting Blueprints</em> by <a href="https://www.linkedin.com/in/herdatom/" target="_blank" rel="noreferrer">Tomas Herda</a></p>
 </footer>
 
 </body>

--- a/02-ai-agents/01-foundations/google-5-day-ai-agents-course.md
+++ b/02-ai-agents/01-foundations/google-5-day-ai-agents-course.md
@@ -16,7 +16,7 @@ Google released massive learning resources for AI Agents, including 10+ code sam
 
 Understand AI agent fundamentals: core architecture, taxonomy of capabilities, and how agents differ from LLMs. Learn to build agents that perceive, plan, act autonomously.
 
-[![Day 1 Preview](../../assets/guides/google-2026/previews/01%20Introduction%20to%20Agents.png)](../../assets/guides/google-2026/01%20Introduction%20to%20Agents.pdf)
+**Whitepaper:** [Introduction to Agents](https://www.kaggle.com/whitepaper-introduction-to-agents)
 
 > [!NOTE]
 > See also our internal [AI Agents Overview](./ai-agents-overview.md) for more context.
@@ -30,7 +30,7 @@ Understand AI agent fundamentals: core architecture, taxonomy of capabilities, a
 
 Learn how agents interact with external systems through tools and APIs. Understand MCP architecture, tool design best practices, and human-in-loop approval workflows.
 
-[![Day 2 Preview](../../assets/guides/google-2026/previews/02%20Agent%20Tools%20%26%20Interoperability%20with%20Model%20Context%20Protocol%20%28MCP%29.png)](../../assets/guides/google-2026/02%20Agent%20Tools%20%26%20Interoperability%20with%20Model%20Context%20Protocol%20%28MCP%29.pdf)
+**Whitepaper:** [Agent Tools & Interoperability with MCP](https://www.kaggle.com/whitepaper-agent-tools-and-interoperability-with-mcp)
 
 
 > [!NOTE]
@@ -45,7 +45,7 @@ Learn how agents interact with external systems through tools and APIs. Understa
 
 Discover how agents maintain context across conversations. Understand Sessions for immediate state and Memory for persistent learning across interactions.
 
-[![Day 3 Preview](../../assets/guides/google-2026/previews/03%20Context%20Engineering%3A%20Sessions%20%26%20Memory.png)](../../assets/guides/google-2026/03%20Context%20Engineering%3A%20Sessions%20%26%20Memory.pdf)
+**Whitepaper:** [Context Engineering: Sessions & Memory](https://www.kaggle.com/whitepaper-context-engineering-sessions-and-memory)
 
 > [!TIP]
 > Compare these approaches with our repository's guide on [Context Engineering](../03-context-and-memory/context-engineering.md).
@@ -59,7 +59,7 @@ Discover how agents maintain context across conversations. Understand Sessions f
 
 Master observability foundations: Logs, Traces, Metrics. Learn evaluation frameworks including LLM-as-a-Judge and Human-in-the-Loop for production reliability.
 
-[![Day 4 Preview](../../assets/guides/google-2026/previews/04%20Agent%20Quality.png)](../../assets/guides/google-2026/04%20Agent%20Quality.pdf)
+**Whitepaper:** [Agent Quality](https://www.kaggle.com/whitepaper-agent-quality)
 
 **Resources**
 - [Code Resource 1: Agent Observability](https://www.kaggle.com/code/kaggle5daysofai/day-4a-agent-observability) | [Code Resource 2: Agent Evaluation](https://www.kaggle.com/code/kaggle5daysofai/day-4b-agent-evaluation)
@@ -70,7 +70,7 @@ Master observability foundations: Logs, Traces, Metrics. Learn evaluation framew
 
 Understand deployment lifecycle and scaling strategies. Learn Agent2Agent Protocol for system-wide coordination and production readiness on Vertex AI.
 
-[![Day 5 Preview](../../assets/guides/google-2026/previews/05%20Prototype%20to%20Production.png)](../../assets/guides/google-2026/05%20Prototype%20to%20Production.pdf)
+**Whitepaper:** [Prototype to Production](https://www.kaggle.com/whitepaper-prototype-to-production)
 
 > [!NOTE]
 > To understand coordination deeper, read our local [Agent-to-Agent (A2A) Protocol Guide](../04-protocols/a2a-protocol-guide.md).

--- a/02-ai-agents/02-skills/anatomy-of-a-skill.md
+++ b/02-ai-agents/02-skills/anatomy-of-a-skill.md
@@ -423,5 +423,5 @@ Symptoms: noticeably slow responses or degraded output quality.
 - [Claude Agent Skills Playbook](./claude-agent-skills.md)
 - [Anthropic — Agent Skills overview](https://www.anthropic.com/news/skills)
 - [Anthropic engineering — Equipping agents for the real world with Agent Skills](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills)
-- [Anthropic – The Complete Guide to Building Skills for Claude (PDF)](../../assets/guides/anthropic-claude-skills-guide.pdf)
+- [Anthropic – The Complete Guide to Building Skills for Claude (PDF)](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf)
 - [Claude Building Skills Guide](../../04-guides/claude-building-skills-guide.md)

--- a/02-ai-agents/02-skills/skills-design-patterns.md
+++ b/02-ai-agents/02-skills/skills-design-patterns.md
@@ -218,5 +218,5 @@ ELSE:
 - [Anatomy of a Claude Agent Skill](./anatomy-of-a-skill.md)
 - [Claude Building Skills Guide](../../04-guides/claude-building-skills-guide.md)
 - [Skills Testing and Iteration](./skills-testing-iteration.md)
-- [Anthropic – The Complete Guide to Building Skills for Claude (PDF)](../../assets/guides/anthropic-claude-skills-guide.pdf)
+- [Anthropic – The Complete Guide to Building Skills for Claude (PDF)](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf)
 - [GitHub — anthropics/skills repository](https://github.com/anthropics/skills)

--- a/02-ai-agents/02-skills/skills-testing-iteration.md
+++ b/02-ai-agents/02-skills/skills-testing-iteration.md
@@ -157,5 +157,5 @@ or reporting.
 - [Anatomy of a Claude Agent Skill](./anatomy-of-a-skill.md)
 - [Claude Building Skills Guide](../../04-guides/claude-building-skills-guide.md)
 - [Skills Design Patterns](./skills-design-patterns.md)
-- [Anthropic – The Complete Guide to Building Skills for Claude (PDF)](../../assets/guides/anthropic-claude-skills-guide.pdf)
+- [Anthropic – The Complete Guide to Building Skills for Claude (PDF)](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf)
 - [GitHub — anthropics/skills repository](https://github.com/anthropics/skills)

--- a/04-guides/claude-building-skills-guide.md
+++ b/04-guides/claude-building-skills-guide.md
@@ -6,7 +6,7 @@ last_updated: "2026-03-15"
 
 # Claude Building Skills Guide
 
-[![Anthropic Claude Skills Guide Preview](../assets/guides/previews/anthropic-claude-skills-guide.png)](../assets/guides/anthropic-claude-skills-guide.pdf)
+**Source:** [Anthropic – The Complete Guide to Building Skills for Claude (PDF)](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf) · [Announcement post](https://claude.com/blog/complete-guide-to-building-skills-for-claude)
 
 ## Why this guide matters
 Skills have effectively replaced classic prompt engineering for AI agents. Instead of rewriting long prompts every time, you can package reusable task intelligence once and apply it across Claude.ai, Claude Code, and API workflows.
@@ -197,7 +197,7 @@ Up to 8 skills per request. Skills require the Code Execution Tool beta for thei
 If prompt engineering helped you get one-off results, skills help you operationalize those results at scale. Start by creating one narrowly scoped skill with strong triggers and clear step-by-step instructions, then compose it with others as your workflows grow.
 
 ## References
-- [Anthropic – The Complete Guide to Building Skills for Claude (PDF)](../assets/guides/anthropic-claude-skills-guide.pdf)
+- [Anthropic – The Complete Guide to Building Skills for Claude (PDF)](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf)
 - [Anthropic — Skills for Claude Agents](https://www.anthropic.com/news/skills)
 - [Anatomy of a Claude Agent Skill](../02-ai-agents/02-skills/anatomy-of-a-skill.md)
 - [Claude Agent Skills Playbook](../02-ai-agents/02-skills/claude-agent-skills.md)

--- a/04-guides/overview.md
+++ b/04-guides/overview.md
@@ -1,73 +1,19 @@
 ---
 title: "Overview"
 tags: ["guides"]
-last_updated: "2026-01-10"
+last_updated: "2026-06-10"
 ---
 
 # Guides Overview
 
-## Gemini Prompting Guide 101
-<figure>
-  <a href="../assets/guides/gemini-prompting-guide-101.pdf">
-    <img src="../assets/guides/previews/gemini-prompting-guide-101.png" alt="Preview of the Gemini Prompting Guide 101 first page" width="100%" loading="lazy" />
-  </a>
-  <figcaption>Click the preview to open the Gemini Prompting Guide 101 PDF.</figcaption>
-</figure>
-
-## Google: Startup Technical Guide for AI Agents
-<figure>
-  <a href="../assets/guides/google-ai-agents-for-startup.pdf">
-    <img src="../assets/guides/previews/google-ai-agents-for-startup.png" alt="Preview of the Google Startup Technical Guide for AI Agents first page" width="100%" loading="lazy" />
-  </a>
-  <figcaption>Click the preview to open the Google Startup Technical Guide for AI Agents PDF.</figcaption>
-</figure>
-
-## OpenAI: A Practical Guide to Building Agents
-<figure>
-  <a href="../assets/guides/openai-a-practical-guide-to-building-agents.pdf">
-    <img src="../assets/guides/previews/openai-a-practical-guide-to-building-agents.png" alt="Preview of OpenAI's practical guide to building agents first page" width="100%" loading="lazy" />
-  </a>
-  <figcaption>Click the preview to open the OpenAI practical guide to building agents PDF.</figcaption>
-</figure>
-
-## OpenAI: AI in the Enterprise
-<figure>
-  <a href="../assets/guides/openai-ai-in-the-enterprise.pdf">
-    <img src="../assets/guides/previews/openai-ai-in-the-enterprise.png" alt="Preview of the OpenAI AI in the Enterprise guide first page" width="100%" loading="lazy" />
-  </a>
-  <figcaption>Click the preview to open the OpenAI AI in the Enterprise PDF.</figcaption>
-</figure>
-
-## OpenAI: Identifying and Scaling AI Use Cases
-<figure>
-  <a href="../assets/guides/openai-identifying-and-scaling-ai-use-cases.pdf">
-    <img src="../assets/guides/previews/openai-identifying-and-scaling-ai-use-cases.png" alt="Preview of the OpenAI identifying and scaling AI use cases guide first page" width="100%" loading="lazy" />
-  </a>
-  <figcaption>Click the preview to open the OpenAI identifying and scaling AI use cases PDF.</figcaption>
-</figure>
-
-## Perplexity: Perplexity at Work Guide
-<figure>
-  <a href="../assets/guides/pplx-at-work.pdf">
-    <img src="../assets/guides/previews/pplx-at-work.png" alt="Preview of the Perplexity at Work guide first page" width="100%" loading="lazy" />
-  </a>
-  <figcaption>Click the preview to open the Perplexity at Work Guide PDF.</figcaption>
-</figure>
-
-## Microsoft: M365 Copilot Prompting Guide
-<figure>
-  <a href="../assets/guides/microsoft-m365-copilot-prompting-guide.pptx">
-    <img src="../assets/guides/previews/microsoft-m365-copilot-prompting-guide.png" alt="Preview of the Microsoft M365 Copilot prompting guide first slide" width="100%" loading="lazy" />
-  </a>
-  <figcaption>Click the preview to open the Microsoft M365 Copilot prompting guide PowerPoint.</figcaption>
-</figure>
+These vendor guides are linked from their official sources rather than redistributed here — each document remains under its owner's copyright and license terms.
 
 ## Guides Library
-- [Gemini Prompting Guide 101](../assets/guides/gemini-prompting-guide-101.pdf) — Core prompting patterns, guardrails, and examples for Gemini models.
-- [Google: Startup Technical Guide for AI Agents](../assets/guides/google-ai-agents-for-startup.pdf) — Technical guide for startups building AI agents.
-- [OpenAI: A Practical Guide to Building Agents](../assets/guides/openai-a-practical-guide-to-building-agents.pdf) — Blueprint for designing agent workflows, orchestration, and evaluation.
-- [OpenAI: AI in the Enterprise](../assets/guides/openai-ai-in-the-enterprise.pdf) — Frameworks for deploying AI capabilities across enterprise functions.
-- [OpenAI: Identifying and Scaling AI Use Cases](../assets/guides/openai-identifying-and-scaling-ai-use-cases.pdf) — Tactics to spot high-value AI opportunities and drive adoption.
-- [Perplexity: Perplexity at Work Guide](../assets/guides/pplx-at-work.pdf) — Adoption roadmap, prompt patterns, and rollout guidelines for Perplexity's enterprise workspace.
-- [Microsoft: M365 Copilot Prompting Guide](../assets/guides/microsoft-m365-copilot-prompting-guide.pptx) — Prompts, patterns, and deployment tips tailored for Microsoft 365 Copilot scenarios.
+- [Gemini Prompting Guide 101](https://services.google.com/fh/files/misc/gemini-for-google-workspace-prompting-guide-101.pdf) — Core prompting patterns, guardrails, and examples for Gemini models. ([Google Workspace landing page](https://workspace.google.com/learning/content/gemini-prompt-guide))
+- [Google: Startup Technical Guide for AI Agents](https://services.google.com/fh/files/misc/startup_technical_guide_ai_agents_final.pdf) — Technical guide for startups building AI agents. ([Google Cloud landing page](https://cloud.google.com/resources/content/building-ai-agents))
+- [OpenAI: A Practical Guide to Building Agents](https://cdn.openai.com/business-guides-and-resources/a-practical-guide-to-building-agents.pdf) — Blueprint for designing agent workflows, orchestration, and evaluation.
+- [OpenAI: AI in the Enterprise](https://cdn.openai.com/business-guides-and-resources/ai-in-the-enterprise.pdf) — Frameworks for deploying AI capabilities across enterprise functions.
+- [OpenAI: Identifying and Scaling AI Use Cases](https://cdn.openai.com/business-guides-and-resources/identifying-and-scaling-ai-use-cases.pdf) — Tactics to spot high-value AI opportunities and drive adoption.
+- [Perplexity: Perplexity at Work Guide](https://r2cdn.perplexity.ai/pdf/pplx-at-work.pdf) — Adoption roadmap, prompt patterns, and rollout guidelines for Perplexity's enterprise workspace. ([Perplexity landing page](https://www.perplexity.ai/enterprise/perplexity-at-work))
+- Microsoft: Recommended Prompts for Microsoft 365 Copilot (August 2025) — Prompts, patterns, and deployment tips tailored for Microsoft 365 Copilot scenarios. No stable public download exists; see Microsoft's [Copilot Prompt Gallery](https://m365.cloud.microsoft/copilot-prompts) and [Microsoft Adoption Copilot resources](https://adoption.microsoft.com/en-us/copilot/) for equivalent material.
 - [Microsoft 365 Copilot Prompting Guide](../05-tools/microsoft-365-copilot-prompting-guide.md) — Markdown digest of Microsoft’s prompt starters, do’s and don’ts, ACRUE rubric, and long-document tactics.

--- a/05-tools/microsoft-365-copilot-prompting-guide.md
+++ b/05-tools/microsoft-365-copilot-prompting-guide.md
@@ -130,5 +130,5 @@ Use the ACRUE rubric to benchmark Copilot responses against other AI systems. Sc
 | **Exceptional** | Does it exceed expectations? | Generic or uninspired | Meets expectations | Surpasses expectations with creativity or depth |
 
 ## References
-- Microsoft. *Recommended Prompts for Microsoft 365 Copilot.* August 2025. Internal slide deck stored at `assets/guides/microsoft-m365-copilot-prompting-guide.pptx`.
+- Microsoft. *Recommended Prompts for Microsoft 365 Copilot.* August 2025. Slide deck distributed by Microsoft; no stable public download available. See the [Microsoft Adoption Copilot resources](https://adoption.microsoft.com/en-us/copilot/) for equivalent material.
 - Microsoft. *Copilot Prompt Gallery.* https://m365.cloud.microsoft/copilot-prompts

--- a/05-tools/microsoft-copilot-researcher-agent.md
+++ b/05-tools/microsoft-copilot-researcher-agent.md
@@ -118,4 +118,4 @@ Microsoft’s official guidance for Researcher in Microsoft 365 Copilot emphasiz
 ## References
 - GPT-Lab. “Effective Prompts for Reasoning LLMs.” https://gpt-lab.eu/effective-prompts-for-reasoning-llms/
 - Microsoft. “Get started with Researcher in Microsoft 365 Copilot.” https://support.microsoft.com/en-us/topic/get-started-with-researcher-in-microsoft-365-copilot-e63ab760-f3de-4c47-ae87-dad601b0e9c4
-- Microsoft. *Recommended Prompts for Microsoft 365 Copilot.* August 2025. Internal slide deck stored at `assets/guides/microsoft-m365-copilot-prompting-guide.pptx`.
+- Microsoft. *Recommended Prompts for Microsoft 365 Copilot.* August 2025. Slide deck distributed by Microsoft; no stable public download available. See the [Microsoft Adoption Copilot resources](https://adoption.microsoft.com/en-us/copilot/) for equivalent material.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -153,8 +153,10 @@ mkdocs build --strict                       # fails on broken nav/links
   clause. Full removal from git history still requires the history purge below.
   (c) Compress images >5 MB (`google_veo_3_1.gif` 16 MB, several speaking photos) and
   the 2.1 MB README hero PNG.
-  (d) Purge the deleted PDF/PPTX blobs from git history (`git filter-repo` + force-push)
-  so they are no longer downloadable from old commits.
+  (d) ~~Purge the deleted PDF/PPTX blobs from git history~~ — done via `git filter-repo`
+  (history rewritten, `.git` 349 MB → 217 MB). Old objects may persist on GitHub's
+  servers until their garbage collection runs; contact GitHub Support to expedite
+  if needed.
 
 - [ ] **P4-02 Cut a release.**
   ~40 entries sit under "Unreleased" and the repo has zero git tags. Move them under

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -146,14 +146,15 @@ mkdocs build --strict                       # fails on broken nav/links
 ## Phase 4 — Cleanup & slimming
 
 - [ ] **P4-01 Asset diet (398 MB → target <100 MB).**
-  (a) Delete byte-identical PDF duplicates: the three OpenAI PDFs exist in both
-  `assets/guides/` and `assets/prompting-guides/` (~22 MB free; keep one location, fix links).
-  (b) Replace vendored third-party PDFs >10 MB with links to the original sources —
-  `pplx-at-work.pdf` (35 MB), `google-ai-agents-for-startup.pdf` (26 MB),
-  `microsoft-m365-copilot-prompting-guide.pptx` (25 MB) — this also resolves the
-  licensing exposure (they are not CC BY 4.0, unlike the repo's declared docs license).
+  (a) ~~Delete byte-identical PDF duplicates~~ — done: `assets/prompting-guides/` removed.
+  (b) ~~Replace vendored third-party PDFs with links to the original sources~~ — done:
+  all 16 third-party PDFs/PPTX and their preview renders removed, references now link
+  to official vendor URLs, and the README license section gained a third-party content
+  clause. Full removal from git history still requires the history purge below.
   (c) Compress images >5 MB (`google_veo_3_1.gif` 16 MB, several speaking photos) and
   the 2.1 MB README hero PNG.
+  (d) Purge the deleted PDF/PPTX blobs from git history (`git filter-repo` + force-push)
+  so they are no longer downloadable from old commits.
 
 - [ ] **P4-02 Cut a release.**
   ~40 entries sit under "Unreleased" and the repo has zero git tags. Move them under

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented here.
 
 ## Unreleased
+- Remove redistributed third-party documents (~176 MB: OpenAI, Google, Perplexity, Anthropic PDFs, the Microsoft M365 Copilot PPTX, and their first-page preview images) and link to the official vendor sources instead, resolving the licensing exposure of shipping non-CC-BY content in the repo.
 - Add AGENTS.md for Claude Code tutorial (`05-tools/agents-md-claude-code-tutorial.md`) covering how to author a new repo's `AGENTS.md`, the AGENTS.md-vs-CLAUDE.md relationship, and connecting it to Claude Code via symlink or `@AGENTS.md` import.
 - Add reference to `multica-ai/andrej-karpathy-skills` (≈154k-star, single-file `CLAUDE.md` implementing Andrej Karpathy's 4-rule baseline) in the 12 Rules for AI Coding Tools guide and the CLAUDE.md design tutorial, plus an entry in `external-sources.md`.
 - Add CI/CD for AI Agents on Microsoft Foundry tutorial (`02-ai-agents/05-production/cicd-ai-agents-microsoft-foundry.md`) covering the five-layer reference architecture, evaluation-driven quality gates, OIDC-based auth, and parallel GitHub Actions / Azure DevOps pipeline implementations for both containerised hosted and declarative prompt-based agents.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Contributions are welcome! Please read [CONTRIBUTING.md](./CONTRIBUTING.md) and 
 
 - **Code:** MIT — see [`LICENSE`](./LICENSE).
 - **Documentation & non-code content:** CC BY 4.0 — see [`docs/LICENSE-CC-BY-4.0.txt`](./docs/LICENSE-CC-BY-4.0.txt).
+- **Third-party content:** The CC BY 4.0 license applies only to original content authored in this repository. Third-party materials (vendor guides, whitepapers, logos, quoted excerpts) remain the property of their respective owners under their own terms; they are linked to their official sources rather than redistributed here, and they are attributed where referenced.
 
 ---
 
@@ -139,7 +140,7 @@ Review ongoing investigations, experiment logs, and calls for collaboration in t
 
 ## FAQ
 **Q: Can I use these prompts commercially?**  
-A: Yes. Code is MIT; docs/prompts are CC BY 4.0 (attribution required).
+A: Yes. Code is MIT; docs/prompts are CC BY 4.0 (attribution required). Linked third-party materials remain under their owners' terms.
 
 **Q: Which models are supported?**  
 A: Patterns are model‑agnostic; guides cover GPT‑5 and Gemini explicitly.

--- a/docs/index.html
+++ b/docs/index.html
@@ -68,7 +68,7 @@
       </div>
 
       <footer class="footer">
-        <div>MIT (code) / CC BY 4.0 (docs) — per repository license.</div>
+        <div>MIT (code) / CC BY 4.0 (original docs) — per repository license. Linked third-party materials remain under their owners' terms.</div>
       </footer>
     </main>
   </div>

--- a/external-sources.md
+++ b/external-sources.md
@@ -22,7 +22,7 @@
 - [Anthropic Skilljar - Claude Certified Architect Foundations Access Request](https://anthropic.skilljar.com/claude-certified-architect-foundations-access-request)
 - [Anthropic Skilljar - Claude Code in Action](https://anthropic.skilljar.com/claude-code-in-action)
 - [Anthropic — Skills for Claude Agents](https://www.anthropic.com/news/skills)
-- [Anthropic – The Complete Guide to Building Skills for Claude (PDF)](assets/guides/anthropic-claude-skills-guide.pdf)
+- [Anthropic – The Complete Guide to Building Skills for Claude (PDF)](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf)
 - [arXiv 2512.15943 — Tool-calling specialization beats scale (PDF)](https://arxiv.org/pdf/2512.15943)
 
 ### B

--- a/source-index.md
+++ b/source-index.md
@@ -45,7 +45,7 @@ Reverse map of every entry in [`external-sources.md`](external-sources.md) to th
   - cited in: `05-tools/claude-code-tool-guide.md`
 - [Anthropic — Skills for Claude Agents](https://www.anthropic.com/news/skills)
   - cited in: `02-ai-agents/02-skills/anatomy-of-a-skill.md`, `02-ai-agents/02-skills/claude-agent-skills.md`, `04-guides/claude-building-skills-guide.md`
-- [Anthropic – The Complete Guide to Building Skills for Claude (PDF)](assets/guides/anthropic-claude-skills-guide.pdf)
+- [Anthropic – The Complete Guide to Building Skills for Claude (PDF)](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf)
   - cited in: `02-ai-agents/02-skills/anatomy-of-a-skill.md`, `02-ai-agents/02-skills/skills-design-patterns.md`, `02-ai-agents/02-skills/skills-testing-iteration.md`, `04-guides/claude-building-skills-guide.md`
 - [arXiv 2512.15943 — Tool-calling specialization beats scale (PDF)](https://arxiv.org/pdf/2512.15943)
   - cited in: `02-ai-agents/01-foundations/models-for-ai-agents-2026.md`


### PR DESCRIPTION
Remove ~176 MB of vendor PDFs/PPTX (OpenAI business guides, Google
startup and Kaggle 5-day agents whitepapers, Gemini Prompting Guide 101,
Perplexity at Work, Anthropic skills guide, Microsoft M365 Copilot
prompting deck) plus their first-page preview renders, none of which are
covered by the repo's CC BY 4.0 docs license. All referencing pages now
link to the official vendor URLs; the Microsoft deck has no stable
public download, so its citations point to Microsoft's adoption
resources instead.

https://claude.ai/code/session_01Un9FwAD4PodXHD7bRxoVFc