### PR TITLE
Add Ornith-1.0 on DGX Spark tutorial

### DIFF
--- a/06-models-and-evaluations/ornith-1-0-dgx-spark-guide.md
+++ b/06-models-and-evaluations/ornith-1-0-dgx-spark-guide.md
@@ -1,0 +1,135 @@
+# Ornith-1.0: Run an Open-Source Agentic Coding LLM on a DGX Spark
+
+## Intent
+Provide a practical guide to **Ornith-1.0**, a new family of open-source, MIT-licensed LLMs built specifically for **agentic coding**, and show how to run the mid-size variant locally on an **NVIDIA DGX Spark**. The headline use case: a local model that codes well, runs 24/7 on a desk-side box, and loops over your repository to find and fix bugs without sending your code to a cloud API.
+
+## Why this matters
+Most frontier coding models are closed and cloud-hosted. Ornith-1.0 is open-weight and small enough that its **35B Mixture-of-Experts (MoE)** variant fits in the **128 GB unified memory of a DGX Spark** — no 200 GB+ server required. That unlocks a new workflow pattern: cheap, private, always-on local agents that loop through your codebase hourly, write security reports with fixes, and review your open PRs. Practitioners running it report it being competitive with — and faster than — larger models on coding tasks, while staying entirely on local hardware.
+
+## What you'll learn
+- The Ornith-1.0 model family, its training approach, and benchmark results.
+- Why the 35B MoE variant is the sweet spot for a DGX Spark.
+- How to download and serve Ornith-1.0 locally with an OpenAI-compatible endpoint.
+- How to wire it into an agentic loop (e.g., an hourly security-scan + fix loop).
+
+## Prerequisites
+- **Hardware**: An NVIDIA DGX Spark (GB10 Grace Blackwell, 128 GB unified LPDDR5x memory) for the 35B MoE variant. The 9B/31B dense models run on a single workstation GPU; the 397B MoE needs a multi-GPU server.
+- **Software**: Recent NVIDIA driver/CUDA stack, Docker, Python 3.10+, and familiarity with an LLM serving engine (vLLM, SGLang, or Ollama).
+- **Accounts**: A Hugging Face account to pull the weights.
+
+## Step 1: Understand the Model Family
+Ornith-1.0 is a family of open-source LLMs specialized for agentic coding, spanning four sizes:
+
+| Variant | Type | Best for |
+| --- | --- | --- |
+| **Ornith-1.0 9B** | Dense | Laptops / single small GPU, lightweight assistants |
+| **Ornith-1.0 31B** | Dense | Single workstation GPU |
+| **Ornith-1.0 35B** | MoE | **DGX Spark (128 GB unified memory)** — the focus of this guide |
+| **Ornith-1.0 397B** | MoE | Multi-GPU servers, frontier-level performance |
+
+Key facts:
+- **License**: MIT (fully open for commercial use).
+- **Base models**: Post-trained on top of `gemma4` and `qwen3.5`.
+- **Training method**: A **self-improving training strategy** in which reinforcement learning generates not only solution rollouts but also the **task-specific scaffolds** that drive those rollouts. By jointly optimizing the scaffold *and* the resulting solution, the model produces higher-quality solutions for agentic coding.
+
+## Step 2: Why the 35B MoE Fits a DGX Spark
+A Mixture-of-Experts model has many parameters but activates only a fraction per token, so it delivers strong quality at a much lower memory and compute cost than a dense model of equal total size. The **35B MoE** variant is the practical target for a DGX Spark because:
+
+- It fits comfortably within the Spark's **128 GB unified memory** (with room for KV cache and context), unlike models that demand 200 GB+ of RAM.
+- MoE sparsity keeps **tokens/sec high**, so an always-on loop stays responsive.
+- It is reported to be **smarter and faster than comparable-size open models** on coding tasks while running locally.
+
+> Rule of thumb: at ~4-bit quantization a 35B MoE needs roughly 20–25 GB for weights, leaving ample headroom on the Spark for long-context agentic sessions.
+
+## Step 3: Download the Weights
+Pull the 35B MoE variant from the Ornith-1.0 Hugging Face collection:
+
+```bash
+pip install -U "huggingface_hub[cli]"
+
+# Replace with the exact repo id from the collection page
+hf download deepreinforce-ai/Ornith-1.0-35B-MoE \
+  --local-dir ./Ornith-1.0-35B-MoE
+```
+
+## Step 4: Serve Ornith-1.0 Locally
+Serve the model behind an OpenAI-compatible API so any agent framework can talk to it.
+
+### Option A: Ollama (simplest on a DGX Spark)
+```bash
+# If the collection ships a GGUF, this is the fastest path
+ollama run ornith-1.0:35b
+```
+This exposes an OpenAI-compatible endpoint at `http://localhost:11434/v1`.
+
+### Option B: vLLM (best throughput for loops)
+```bash
+docker pull vllm/vllm-openai:latest
+
+vllm serve ./Ornith-1.0-35B-MoE \
+  --gpu-memory-utilization 0.85 \
+  --max-model-len 32768 \
+  --served-model-name ornith-1.0-35b
+```
+
+### Option C: SGLang
+```bash
+python3 -m sglang.launch_server \
+  --model-path ./Ornith-1.0-35B-MoE \
+  --mem-fraction-static 0.85 \
+  --served-model-name ornith-1.0-35b
+```
+
+Verify the endpoint:
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "ornith-1.0-35b",
+    "messages": [{"role": "user", "content": "Write a Python function to detect SQL injection in a query string."}]
+  }'
+```
+
+## Step 5: Build an Always-On Agentic Loop
+The standout pattern for a local model is a **24/7 loop** over your own codebase. A common setup:
+
+1. **Hourly security scan** — point an agent (Codex CLI, Claude Code with a local provider, or a custom script) at the local endpoint and loop it over different parts of the repo. For each pass it scans for security vulnerabilities and, for anything it finds, **writes a report containing the proposed fix**.
+2. **Daily verify-and-fix loop** — a second loop reads that report, **verifies** each finding against the code, and applies fixes.
+3. **Daily PR review** — a third loop walks all open pull requests and leaves review notes.
+
+Minimal scheduler sketch:
+```bash
+# /etc/cron.d/ornith-loops  — runs against the local Ornith endpoint
+0 * * * *  user  /opt/agents/security-scan.sh   >> /var/log/ornith-scan.log 2>&1
+30 3 * * * user  /opt/agents/verify-and-fix.sh   >> /var/log/ornith-fix.log 2>&1
+0 4 * * *  user  /opt/agents/review-open-prs.sh  >> /var/log/ornith-pr.log 2>&1
+```
+
+Each script just sends prompts to `http://localhost:8000/v1` (or the Ollama port) and writes Markdown reports into the repo. Because inference is local, you can run these as often as you like at no per-token cost and without exposing source code to a third party.
+
+## Step 6: Benchmark Context
+Per the model release, Ornith-1.0 achieves state-of-the-art results among open-source models of comparable size on coding benchmarks:
+
+| Benchmark | Score |
+| --- | --- |
+| Terminal-Bench 2.1 | **77.5** |
+| SWE-Bench Verified | **82.4** |
+| SWE-Bench Pro | **62.2** |
+| SWE-Bench Multilingual | **78.9** |
+| NL2Repo | **48.2** |
+| SWE Atlas — QnA | **41.2** |
+| SWE Atlas — RF | **42.6** |
+| SWE Atlas — TW | **39.1** |
+| ClawEval | **77.1** |
+
+> In the published evaluation chart, the flagship **Ornith-1.0-397B** is compared against models such as Qwen3.5-397B, Qwen3.7-Max, GLM-5.2-744B, Minimax-M3-428B, DeepSeek-V4-Pro-1.6T, and Claude Opus 4.7/4.8, leading or matching the field on Terminal-Bench, SWE-bench Pro, SWE-bench Multilingual, and Claw-eval Avg.
+
+## Takeaways
+- Ornith-1.0 is an **MIT-licensed, open-weight** family purpose-built for agentic coding.
+- The **35B MoE** variant is the practical pick for a **DGX Spark**: strong coding quality without 200 GB+ of RAM.
+- Serve it behind an OpenAI-compatible API and run **scheduled, local 24/7 loops** for security scanning, fixes, and PR review — private, cheap, and always on.
+
+## References
+- [Ornith-1.0 Tech Blog (deep-reinforce.com)](https://deep-reinforce.com/ornith_1_0.html)
+- [Ornith-1.0 Hugging Face Collection](https://huggingface.co/collections/deepreinforce-ai/ornith-10)
+- [NVIDIA DGX Spark](https://www.nvidia.com/en-us/products/workstations/dgx-spark/)

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Your guide to the Agentic AI evolution. **Prompting Blueprints** offers a curate
 The five most recently added pages (auto-generated from git history — do not edit by hand):
 
 <!-- RECENT_ADDITIONS:START -->
+- **2026-06-26** · [Ornith-1.0: Run an Open-Source Agentic Coding LLM on a DGX Spark](./06-models-and-evaluations/ornith-1-0-dgx-spark-guide.md)
 - **2026-06-23** · [Banking AI Governance Use-Case Tutorial (Santander AI Open Source)](./07-use-cases-and-research/santander-ai-banking-governance.md)
 - **2026-06-23** · [Agent Fleet Governance (Fleet Engineering)](./02-ai-agents/01-foundations/agent-fleet-governance.md)
 - **2026-06-14** · [Build a Local Hermes Daily Assistant (Qwen3 + Ollama + Unsloth + Obsidian)](./05-tools/hermes-daily-assistant-setup.md)
 - **2026-06-14** · [Loop Engineering (and How to Avoid Loopmaxxing)](./02-ai-agents/01-foundations/loop-engineering.md)
-- **2026-06-07** · [GAISE 2026 — Conference Notes](./09-conferences/gaise-2026.md)
 <!-- RECENT_ADDITIONS:END -->
 
 ---

--- a/external-sources.md
+++ b/external-sources.md
@@ -118,6 +118,7 @@
 - [Hermes Agent (Nous Research)](https://hermes-agent.nousresearch.com)
 - [Hugging Face – HF Skills: training a fine-tuning agent with Claude Code](https://huggingface.co/blog/hf-skills-training)
 - [Hugging Face Model Card – GLM-5](https://huggingface.co/zai-org/GLM-5)
+- [Hugging Face – Ornith-1.0 Collection (deepreinforce-ai)](https://huggingface.co/collections/deepreinforce-ai/ornith-10)
 
 ### J
 - [Joshua Kubicki – The Era of Vibe Research Is Here](https://makelaw.substack.com/p/the-era-of-vibe-research-is-here)
@@ -178,9 +179,11 @@
 - [n8n – Workflow templates gallery](https://n8n.io/workflows/)
 - [Next.js](https://nextjs.org/)
 - [NinjaTech — Deep Research prompt best practices](https://www.ninjatech.ai/blog/how-to-use-deep-research-best-practices-for-crafting-effective-prompts#:~:text=%2A%20Strong%20Prompt%3A%20,in%20the%20next%20five%20years)
+- [NVIDIA DGX Spark](https://www.nvidia.com/en-us/products/workstations/dgx-spark/)
 
 ### O
 - [Obsidian – Note-taking and knowledge management app](https://obsidian.md)
+- [Ornith-1.0 Tech Blog (deep-reinforce.com)](https://deep-reinforce.com/ornith_1_0.html)
 - [Ollama – Run open models locally](https://ollama.com)
 - [OpenAI Codex quickstart](https://developers.openai.com/codex/quickstart/)
 - [On Tech Ethics Podcast – Vibe Research and the Future of Science (CITI Program)](https://about.citiprogram.org/blog/on-tech-ethics-podcast-vibe-research-and-the-future-of-science/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
     - Overview: 06-models-and-evaluations/README.md
     - Gemini Nano Banana Pro Prompt Library: 06-models-and-evaluations/nano-banana-pro-library.md
     - GLM-5 Setup & Serving Guide: 06-models-and-evaluations/glm-5-guide.md
+    - Ornith-1.0 on DGX Spark Guide: 06-models-and-evaluations/ornith-1-0-dgx-spark-guide.md
     - Google Veo 3.1 Video Tutorial: 06-models-and-evaluations/google-veo-3-1-video-tutorial.md
     - FACTS Benchmark Overview: 06-models-and-evaluations/facts-benchmark-overview.md
     - Aggregated Suite (promptfoo.yml): 06-models-and-evaluations/promptfoo.yml

--- a/source-index.md
+++ b/source-index.md
@@ -211,6 +211,8 @@ Reverse map of every entry in [`external-sources.md`](external-sources.md) to th
   - cited in: `04-guides/claude-fine-tune-llm.md`
 - [Hugging Face Model Card – GLM-5](https://huggingface.co/zai-org/GLM-5)
   - cited in: `06-models-and-evaluations/glm-5-guide.md`
+- [Hugging Face – Ornith-1.0 Collection (deepreinforce-ai)](https://huggingface.co/collections/deepreinforce-ai/ornith-10)
+  - cited in: `06-models-and-evaluations/ornith-1-0-dgx-spark-guide.md`
 - [Joshua Kubicki – The Era of Vibe Research Is Here](https://makelaw.substack.com/p/the-era-of-vibe-research-is-here)
   - cited in: `07-use-cases-and-research/vibe-research.md`
 - [Kaggle 5-Day AI Agents Course Guide](https://www.kaggle.com/learn-guide/5-day-agents)
@@ -309,8 +311,12 @@ Reverse map of every entry in [`external-sources.md`](external-sources.md) to th
   - cited in: `04-guides/vibe-coding-tech-stack.md`
 - [NinjaTech — Deep Research prompt best practices](https://www.ninjatech.ai/blog/how-to-use-deep-research-best-practices-for-crafting-effective-prompts#:~:text=%2A%20Strong%20Prompt%3A%20,in%20the%20next%20five%20years)
   - cited in: `07-use-cases-and-research/deep-research.md`
+- [NVIDIA DGX Spark](https://www.nvidia.com/en-us/products/workstations/dgx-spark/)
+  - cited in: `06-models-and-evaluations/ornith-1-0-dgx-spark-guide.md`
 - [Obsidian – Note-taking and knowledge management app](https://obsidian.md)
   - cited in: `02-ai-agents/03-context-and-memory/ai-knowledge-base-tutorial.md`, `05-tools/hermes-daily-assistant-setup.md`
+- [Ornith-1.0 Tech Blog (deep-reinforce.com)](https://deep-reinforce.com/ornith_1_0.html)
+  - cited in: `06-models-and-evaluations/ornith-1-0-dgx-spark-guide.md`
 - [Ollama – Run open models locally](https://ollama.com)
   - cited in: `05-tools/hermes-daily-assistant-setup.md`
 - [OpenAI Codex quickstart](https://developers.openai.com/codex/quickstart/)


### PR DESCRIPTION
Introduce a guide to the MIT-licensed Ornith-1.0 open-source agentic
coding LLM family, focused on running the 35B MoE variant locally on an
NVIDIA DGX Spark. Covers model family, the self-improving RL training
approach, download/serving (Ollama, vLLM, SGLang), an always-on 24/7
agentic loop pattern, and published benchmark results.

Register sources in external-sources.md, regenerate source-index.md, and
add the page to the mkdocs nav.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Wvm2GkyG7seHNFGjM1pHwT