### PR TITLE
Add "AI People to Follow" curated page

### DIFF
--- a/01-about-author/ai-people-to-follow.md
+++ b/01-about-author/ai-people-to-follow.md
@@ -1,0 +1,95 @@
+---
+title: "AI People to Follow"
+tags: ["people", "about-author", "curated"]
+last_updated: "2026-06-29"
+---
+
+# AI People to Follow
+
+A curated list of people worth following on AI topics — agents, prompting, coding
+assistants, open models, and applied research.
+
+!!! note "How this list is built"
+    This is opinionated and deliberately small. Most entries are **grounded in
+    sources already cited across this repository** (see
+    [`external-sources.md`](../external-sources.md)) — so each person connects to a
+    guide, tutorial, or reference you'll find here. A few widely recognized voices
+    are added as **curated picks** even where the repo doesn't yet cite them; those
+    are marked _(curated)_. Inclusion is about signal and teaching value, not a
+    ranking.
+
+---
+
+## AI Coding & Agents
+
+People building and explaining coding assistants, agent frameworks, and the
+practice of working with them.
+
+| Person | Focus | Follow | Connected in this repo |
+|--------|-------|--------|------------------------|
+| **Andrej Karpathy** | Foundational LLM education; nanoGPT, nanochat, the "LLM Wiki" knowledge-base pattern | [karpathy (GitHub)](https://github.com/karpathy) | [nanoGPT + nanochat guide](../05-tools/nanogpt-tool-guide.md), [AI Knowledge Base tutorial](../02-ai-agents/03-context-and-memory/ai-knowledge-base-tutorial.md) |
+| **Boris Cherny** | Claude Code — creator and lead | [@bcherny (X)](https://x.com/bcherny) | Claude Code tooling guides in [05-tools](../05-tools/claude-code-tool-guide.md) |
+| **Thariq Shihipar** | Claude / agent UX at Anthropic | [@trq212 (X)](https://x.com/trq212) | Claude agent & skills playbooks in [02-ai-agents](../02-ai-agents/02-skills/claude-agent-skills.md) |
+| **Addy Osmani** | Engineering practice, vibe coding, the evolving SDLC | [addyosmani.com](https://addyosmani.com/) | ["The New SDLC with Vibe Coding" whitepaper](../04-guides/vibe-coding-tech-stack.md) |
+
+---
+
+## Educators & Explainers
+
+People who make AI concepts, tools, and workflows accessible.
+
+| Person | Focus | Follow | Connected in this repo |
+|--------|-------|--------|------------------------|
+| **Jules White** | Prompt patterns; the Prompt Pattern Catalog | [Vanderbilt — Prompt Patterns](https://www.vanderbilt.edu/generative-ai/prompt-patterns/) | [Prompt Pattern Catalogue](../03-prompts-and-patterns/prompt-pattern-catalogue.md) |
+| **Cobus Greyling** | Conversational AI, agents, and the evolving AI vocabulary | [Cobus Greyling (Medium)](https://cobusgreyling.medium.com/) | [Generative AI terms glossary](../04-guides/genai-terms-explained-v2.md) |
+| **Joe Njenga** | Practical Claude Code workflows and write-ups | [Joe Njenga (Medium)](https://medium.com/@joe.njenga) | Claude Code guides in [05-tools](../05-tools/claude-code-tool-guide.md) |
+| **Daniel Avila** | AI coding tools and tutorials | [Daniel Avila (Medium)](https://medium.com/@dan.avila7) | Tooling tutorials in [05-tools](../05-tools/) |
+| **Pamela Fox** | Python, MCP servers (FastMCP), developer education | [pamelafox (GitHub)](https://github.com/pamelafox) | [MCP guide](../02-ai-agents/04-protocols/mcp-guide.md) |
+| **Andrew Ng** _(curated)_ | AI education at scale; DeepLearning.AI short courses | [DeepLearning.AI](https://www.deeplearning.ai/) | DeepLearning.AI Claude Code course (cited in tooling guides) |
+
+---
+
+## Applied & Vibe Research
+
+People exploring how agents change research and knowledge work.
+
+| Person | Focus | Follow | Connected in this repo |
+|--------|-------|--------|------------------------|
+| **Joshua Kubicki** | Vibe research; AI in professional/legal work | [makelaw (Substack)](https://makelaw.substack.com/) | [Vibe Research playbook](../07-use-cases-and-research/vibe-research.md) |
+| **Albertina Bekhti** | Agents and the future of scientific discovery | [abertina (Medium)](https://medium.com/@abertina) | [Vibe Research playbook](../07-use-cases-and-research/vibe-research.md) |
+| **Daniel Agrici** | Personal knowledge management with Claude (claude-obsidian) | [AgriciDaniel (GitHub)](https://github.com/AgriciDaniel) | [AI Knowledge Base tutorial](../02-ai-agents/03-context-and-memory/ai-knowledge-base-tutorial.md) |
+
+---
+
+## Labs & Org Accounts to Watch _(curated)_
+
+Following the orgs is often the fastest way to catch model and tooling releases
+referenced throughout this repo.
+
+| Account | Why follow |
+|---------|-----------|
+| **Anthropic** | Claude, Claude Code, Agent Skills — see [anthropic.com](https://www.anthropic.com/) |
+| **OpenAI** | GPT models, Codex, Deep Research — see [openai.com](https://openai.com/) |
+| **Google DeepMind / Google AI** | Gemini, ADK, NotebookLM, FACTS benchmark — see [deepmind.google](https://deepmind.google/) |
+| **Hugging Face** | Open models, skills, and community tooling — see [huggingface.co](https://huggingface.co/) |
+| **LangChain** | Agent frameworks (LangGraph, Deep Agents) — see [langchain.com](https://www.langchain.com/) |
+
+---
+
+## How to extend this list
+
+When you add a person, prefer those who already connect to a source in this repo:
+
+1. Add their profile/reference URL to [`external-sources.md`](../external-sources.md).
+2. Cite that exact URL on the relevant content page (and/or here).
+3. Run `python3 scripts/build-source-index.py` so [`source-index.md`](../source-index.md)
+   picks up the new citation.
+
+Mark anyone not yet grounded in a repo source as _(curated)_ until a citing page exists.
+
+---
+
+> Maintained as part of [Prompting Blueprints](../README.md). Suggestions welcome —
+> see [CONTRIBUTING.md](../CONTRIBUTING.md).
+</content>
+</invoke>

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The five most recently added pages (auto-generated from git history — do not e
 
 ## TL;DR
 - **About the author:** speaking, program committee, and research overviews -> `./01-about-author`
+- **AI people to follow:** curated list of voices to follow on AI, grounded in this repo's references -> `./01-about-author/ai-people-to-follow.md`
 - **AI agents:** agent architectures, protocols (MCP/A2A), context engineering (incl. dynamic context discovery), open models, and skills playbooks -> `./02-ai-agents`
 - **Prompts & patterns:** prompt packs and reusable scaffolds (role + constraints + format) -> `./03-prompts-and-patterns`
 - **Guides:** deep-dive primers with links to official vendor guides (Gemini Prompting Guide 101, Google Startup AI Agents) -> `./04-guides` (see `./04-guides/overview.md`)

--- a/external-sources.md
+++ b/external-sources.md
@@ -4,7 +4,11 @@
 
 ### A
 - [A Prompt Pattern Catalog to Enhance Prompt Engineering with ChatGPT (arXiv 2302.11382)](https://arxiv.org/abs/2302.11382)
+- [Addy Osmani – personal site](https://addyosmani.com/)
 - [Agrici Daniel – claude-obsidian: AI-Powered Knowledge Management System (GitHub)](https://github.com/AgriciDaniel/claude-obsidian)
+- [Agrici Daniel – GitHub profile](https://github.com/AgriciDaniel)
+- [Andrej Karpathy – GitHub profile](https://github.com/karpathy)
+- [Anthropic – home](https://www.anthropic.com/)
 - [A Prompt Pattern Catalog to Enhance Prompt Engineering with ChatGPT (arXiv 2302.11382 PDF)](https://arxiv.org/pdf/2302.11382)
 - [A2A .NET SDK (GitHub)](https://github.com/a2aproject/a2a-dotnet)
 - [A2A Protocol Documentation – Get started](https://a2a-protocol.org/latest/#get-started-with-a2a)
@@ -37,6 +41,7 @@
 - [Claude - Claude Cowork product page](https://claude.com/product/cowork)
 - [Claude Code quickstart](https://code.claude.com/docs/en/quickstart)
 - [Clerk](https://clerk.com/)
+- [Cobus Greyling – Medium profile](https://cobusgreyling.medium.com/)
 - [Cobus Greyling – The Evolving Vocabulary of AI](https://cobusgreyling.medium.com/the-evolving-vocabulary-of-ai-2ea12100811d)
 - [Code Newsletter - THE CODE](https://codenewsletter.ai/subscribe?utm_source=linkedin_profile_om)
 - [Codelab: Get started with Google Antigravity](https://codelabs.developers.google.com/getting-started-google-antigravity#0)
@@ -55,6 +60,8 @@
 - [DAiTA — Intelligente Dokumentenverarbeitung Plattform (DE, Österreichische Post)](https://www.post.at/g/c/daita)
 - [DAIR.AI Thinkific - Claude Code for Everyone](https://dair-ai.thinkific.com/courses/claude-code)
 - [DeepLearning.AI - Claude Code: A Highly Agentic Coding Assistant](https://www.deeplearning.ai/short-courses/claude-code-a-highly-agentic-coding-assistant/)
+- [DeepLearning.AI – home](https://www.deeplearning.ai/)
+- [DeepMind – home](https://deepmind.google/)
 - [DeepMind – FACTS Benchmark suite: systematically evaluating the factuality of large language models](https://deepmind.google/blog/facts-benchmark-suite-systematically-evaluating-the-factuality-of-large-language-models/)
 - [DeepSeek](https://www.deepseek.com/)
 
@@ -93,6 +100,7 @@
 - [GitHub – Microsoft Agent Framework (.git)](https://github.com/microsoft/agent-framework.git)
 - [GitHub – Microsoft Agent Framework](https://github.com/microsoft/agent-framework)
 - [GitHub – nanoGPT](https://github.com/karpathy/nanoGPT)
+- [GitHub – Pamela Fox profile](https://github.com/pamelafox)
 - [GitHub – Strands agent-sop repository](https://github.com/strands-agents/agent-sop/tree/main)
 - [GLM-5 GitHub Repository](https://github.com/zai-org/GLM-5)
 - [Google ADK Python GitHub Repository](https://github.com/google/adk-python)
@@ -116,12 +124,14 @@
 
 ### H
 - [Hermes Agent (Nous Research)](https://hermes-agent.nousresearch.com)
+- [Hugging Face – home](https://huggingface.co/)
 - [Hugging Face – HF Skills: training a fine-tuning agent with Claude Code](https://huggingface.co/blog/hf-skills-training)
 - [Hugging Face Model Card – GLM-5](https://huggingface.co/zai-org/GLM-5)
 - [Hugging Face – Ornith-1.0 Collection (deepreinforce-ai)](https://huggingface.co/collections/deepreinforce-ai/ornith-10)
 
 ### J
 - [Joshua Kubicki – The Era of Vibe Research Is Here](https://makelaw.substack.com/p/the-era-of-vibe-research-is-here)
+- [Joshua Kubicki – makelaw (Substack profile)](https://makelaw.substack.com/)
 
 ### K
 
@@ -137,6 +147,7 @@
 - [LangChain Deep Agents Repository (tree/master)](https://github.com/langchain-ai/deepagents/tree/master)
 - [LangChain Deep Agents – research_agent.py example](https://github.com/langchain-ai/deepagents/blob/master/examples/research/research_agent.py)
 - [LangChain – LangGraph Studio docs](https://docs.langchain.com/oss/python/langgraph/studio)
+- [LangChain – home](https://www.langchain.com/)
 - [LangGraph – Official site](https://www.langchain.com/langgraph)
 - [LM Studio blog – FunctionGemma + Unsloth tutorial](https://lmstudio.ai/blog/functiongemma-unsloth)
 - [Lovable](https://lovable.dev/)
@@ -147,6 +158,7 @@
 - [M365copilot.com](https://www.m365copilot.com)
 - [Make](https://www.make.com/)
 - [Manus – Research Agent Workspace](https://manus.im/)
+- [Medium - Albertina Bekhti profile](https://medium.com/@abertina)
 - [Medium - Daniel Avila](https://medium.com/@dan.avila7)
 - [Medium - Joe Njenga](https://medium.com/@joe.njenga)
 - [Medium - Joe Njenga Claude Code list](https://medium.com/@joe.njenga/list/claude-code-bd02c285e37f)
@@ -191,6 +203,7 @@
 - [OpenAI Academy – Use cases for managers](https://academy.openai.com/public/clubs/work-users-ynjqu/resources/use-cases-for-managers)
 - [OpenAI – Agents API guide](https://platform.openai.com/docs/guides/agents)
 - [OpenAI – ChatGPT](https://openai.com/chatgpt)
+- [OpenAI – home](https://openai.com/)
 - [OpenAI – Codex](https://openai.com/blog/openai-codex)
 - [OpenAI Codex – AGENTS.md guide](https://developers.openai.com/codex/guides/agents-md)
 - [OpenAI Codex – Prompting guide](https://developers.openai.com/codex/prompting)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,6 +117,7 @@ nav:
     - Open Models for Agentic AI: 02-ai-agents/01-foundations/open-models.md
   - About the Author:
     - Tomas Herda Biography: 01-about-author/tomas-herda-biography.md
+    - AI People to Follow: 01-about-author/ai-people-to-follow.md
   - Speaking & Keynotes:
     - Overview: 01-about-author/speaking/index.md
     - Program Committee & Track Leadership: 01-about-author/program-committee/index.md

--- a/source-index.md
+++ b/source-index.md
@@ -9,8 +9,16 @@ Reverse map of every entry in [`external-sources.md`](external-sources.md) to th
 
 - [A Prompt Pattern Catalog to Enhance Prompt Engineering with ChatGPT (arXiv 2302.11382)](https://arxiv.org/abs/2302.11382)
   - cited in: `02-ai-agents/01-foundations/ai-agents-overview.md`
+- [Addy Osmani – personal site](https://addyosmani.com/)
+  - cited in: `01-about-author/ai-people-to-follow.md`
 - [Agrici Daniel – claude-obsidian: AI-Powered Knowledge Management System (GitHub)](https://github.com/AgriciDaniel/claude-obsidian)
   - cited in: `02-ai-agents/03-context-and-memory/ai-knowledge-base-tutorial.md`, `05-tools/hermes-daily-assistant-setup.md`
+- [Agrici Daniel – GitHub profile](https://github.com/AgriciDaniel)
+  - cited in: `01-about-author/ai-people-to-follow.md`
+- [Andrej Karpathy – GitHub profile](https://github.com/karpathy)
+  - cited in: `01-about-author/ai-people-to-follow.md`
+- [Anthropic – home](https://www.anthropic.com/)
+  - cited in: `01-about-author/ai-people-to-follow.md`
 - [A Prompt Pattern Catalog to Enhance Prompt Engineering with ChatGPT (arXiv 2302.11382 PDF)](https://arxiv.org/pdf/2302.11382)
   - cited in: `03-prompts-and-patterns/prompt-pattern-catalogue.md`
 - [A2A .NET SDK (GitHub)](https://github.com/a2aproject/a2a-dotnet)
@@ -67,6 +75,8 @@ Reverse map of every entry in [`external-sources.md`](external-sources.md) to th
   - cited in: `02-ai-agents/03-context-and-memory/agents-md-claude-code-tutorial.md`, `05-tools/coding-ai-agent-selection-tutorial.md`
 - [Clerk](https://clerk.com/)
   - cited in: `04-guides/vibe-coding-tech-stack.md`
+- [Cobus Greyling – Medium profile](https://cobusgreyling.medium.com/)
+  - cited in: `01-about-author/ai-people-to-follow.md`
 - [Cobus Greyling – The Evolving Vocabulary of AI](https://cobusgreyling.medium.com/the-evolving-vocabulary-of-ai-2ea12100811d)
   - cited in: `02-ai-agents/01-foundations/agent-fleet-governance.md`, `02-ai-agents/01-foundations/prompt-context-harness-engineering.md`
 - [Code Newsletter - THE CODE](https://codenewsletter.ai/subscribe?utm_source=linkedin_profile_om)
@@ -99,6 +109,10 @@ Reverse map of every entry in [`external-sources.md`](external-sources.md) to th
   - cited in: `05-tools/claude-code-tool-guide.md`
 - [DeepLearning.AI - Claude Code: A Highly Agentic Coding Assistant](https://www.deeplearning.ai/short-courses/claude-code-a-highly-agentic-coding-assistant/)
   - cited in: `05-tools/claude-code-tool-guide.md`
+- [DeepLearning.AI – home](https://www.deeplearning.ai/)
+  - cited in: `01-about-author/ai-people-to-follow.md`
+- [DeepMind – home](https://deepmind.google/)
+  - cited in: `01-about-author/ai-people-to-follow.md`
 - [DeepMind – FACTS Benchmark suite: systematically evaluating the factuality of large language models](https://deepmind.google/blog/facts-benchmark-suite-systematically-evaluating-the-factuality-of-large-language-models/)
   - cited in: `06-models-and-evaluations/facts-benchmark-overview.md`
 - [DeepSeek](https://www.deepseek.com/)
@@ -165,6 +179,8 @@ Reverse map of every entry in [`external-sources.md`](external-sources.md) to th
   - cited in: `05-tools/microsoft-agent-framework.md`
 - [GitHub – nanoGPT](https://github.com/karpathy/nanoGPT)
   - cited in: `05-tools/nanogpt-tool-guide.md`
+- [GitHub – Pamela Fox profile](https://github.com/pamelafox)
+  - cited in: `01-about-author/ai-people-to-follow.md`
 - [GitHub – Strands agent-sop repository](https://github.com/strands-agents/agent-sop/tree/main)
   - cited in: `05-tools/spec-driven-development-tutorial.md`
 - [GLM-5 GitHub Repository](https://github.com/zai-org/GLM-5)
@@ -207,6 +223,8 @@ Reverse map of every entry in [`external-sources.md`](external-sources.md) to th
   - cited in: `03-prompts-and-patterns/researchers-prompting-blueprints.md`, `03-prompts-and-patterns/writers-prompting-blueprints.md`, `05-tools/microsoft-copilot-researcher-agent.md`, `09-conferences/gaise-2026.md`
 - [Hermes Agent (Nous Research)](https://hermes-agent.nousresearch.com)
   - cited in: `05-tools/hermes-agent-tutorial.md`, `05-tools/hermes-daily-assistant-setup.md`
+- [Hugging Face – home](https://huggingface.co/)
+  - cited in: `01-about-author/ai-people-to-follow.md`
 - [Hugging Face – HF Skills: training a fine-tuning agent with Claude Code](https://huggingface.co/blog/hf-skills-training)
   - cited in: `04-guides/claude-fine-tune-llm.md`
 - [Hugging Face Model Card – GLM-5](https://huggingface.co/zai-org/GLM-5)
@@ -215,6 +233,8 @@ Reverse map of every entry in [`external-sources.md`](external-sources.md) to th
   - cited in: `06-models-and-evaluations/ornith-1-0-dgx-spark-guide.md`
 - [Joshua Kubicki – The Era of Vibe Research Is Here](https://makelaw.substack.com/p/the-era-of-vibe-research-is-here)
   - cited in: `07-use-cases-and-research/vibe-research.md`
+- [Joshua Kubicki – makelaw (Substack profile)](https://makelaw.substack.com/)
+  - cited in: `01-about-author/ai-people-to-follow.md`
 - [Kaggle 5-Day AI Agents Course Guide](https://www.kaggle.com/learn-guide/5-day-agents)
   - cited in: `02-ai-agents/01-foundations/google-5-day-ai-agents-course.md`
 - [Kaggle / Google – The New SDLC with Vibe Coding (whitepaper, Addy Osmani, Shubham Saboo, Sokratis Kartakis)](https://www.kaggle.com/whitepaper-the-new-SDLC-with-vibe-coding)
@@ -235,6 +255,8 @@ Reverse map of every entry in [`external-sources.md`](external-sources.md) to th
   - cited in: `05-tools/langchain-deep-agents.md`
 - [LangChain – LangGraph Studio docs](https://docs.langchain.com/oss/python/langgraph/studio)
   - cited in: `02-ai-agents/01-foundations/ai-agents-overview.md`
+- [LangChain – home](https://www.langchain.com/)
+  - cited in: `01-about-author/ai-people-to-follow.md`
 - [LangGraph – Official site](https://www.langchain.com/langgraph)
   - cited in: `05-tools/n8n-vs-langgraph.md`
 - [LM Studio blog – FunctionGemma + Unsloth tutorial](https://lmstudio.ai/blog/functiongemma-unsloth)
@@ -251,10 +273,12 @@ Reverse map of every entry in [`external-sources.md`](external-sources.md) to th
   - cited in: `02-ai-agents/01-foundations/ai-coding-spectrum.md`
 - [Manus – Research Agent Workspace](https://manus.im/)
   - cited in: `05-tools/best-ai-apps-2026.md`, `05-tools/langchain-deep-agents.md`
+- [Medium - Albertina Bekhti profile](https://medium.com/@abertina)
+  - cited in: `01-about-author/ai-people-to-follow.md`
 - [Medium - Daniel Avila](https://medium.com/@dan.avila7)
-  - cited in: `05-tools/claude-code-tool-guide.md`
+  - cited in: `01-about-author/ai-people-to-follow.md`, `05-tools/claude-code-tool-guide.md`
 - [Medium - Joe Njenga](https://medium.com/@joe.njenga)
-  - cited in: `05-tools/claude-code-tool-guide.md`
+  - cited in: `01-about-author/ai-people-to-follow.md`, `05-tools/claude-code-tool-guide.md`
 - [Medium - Joe Njenga Claude Code list](https://medium.com/@joe.njenga/list/claude-code-bd02c285e37f)
   - cited in: `05-tools/claude-code-tool-guide.md`
 - [Medium - JP Caparas](https://jpcaparas.medium.com/)
@@ -331,6 +355,8 @@ Reverse map of every entry in [`external-sources.md`](external-sources.md) to th
   - cited in: `02-ai-agents/01-foundations/ai-agents-overview.md`
 - [OpenAI – ChatGPT](https://openai.com/chatgpt)
   - cited in: `04-guides/vibe-coding-tech-stack.md`, `05-tools/ai-tool-chaining-oct-2025.md`
+- [OpenAI – home](https://openai.com/)
+  - cited in: `01-about-author/ai-people-to-follow.md`, `02-ai-agents/03-context-and-memory/agent-context-window-performance.md`
 - [OpenAI – Codex](https://openai.com/blog/openai-codex)
   - cited in: `02-ai-agents/01-foundations/ai-coding-spectrum.md`
 - [OpenAI Codex – AGENTS.md guide](https://developers.openai.com/codex/guides/agents-md)
@@ -404,15 +430,15 @@ Reverse map of every entry in [`external-sources.md`](external-sources.md) to th
 - [Vanderbilt – ChatGPT Advanced Data Analysis course announcement](https://www.vanderbilt.edu/datascience/2023/08/29/new-course-chatgpt-advanced-data-analysis-by-dr-jules-white-associate-professor-of-computer-science/)
   - cited in: `02-ai-agents/01-foundations/ai-agents-overview.md`
 - [Vanderbilt University – Prompt Patterns collection](https://www.vanderbilt.edu/generative-ai/prompt-patterns/)
-  - cited in: `02-ai-agents/01-foundations/ai-agents-overview.md`
+  - cited in: `01-about-author/ai-people-to-follow.md`, `02-ai-agents/01-foundations/ai-agents-overview.md`
 - [Vom Brocke et al. – How to Identify Promising AI Use Cases](https://www.alexandria.unisg.ch/server/api/core/bitstreams/35316f07-8d0b-47dc-bbf0-36753ca834b3/content)
   - cited in: `07-use-cases-and-research/ai-use-case-identification.md`
 - [Wei et al. – Chain-of-thought prompting elicits reasoning in large language models](https://arxiv.org/abs/2201.11903)
   - cited in: `02-ai-agents/01-foundations/ai-agents-overview.md`
 - [X - Boris Cherny](https://x.com/bcherny)
-  - cited in: `05-tools/claude-code-tool-guide.md`
+  - cited in: `01-about-author/ai-people-to-follow.md`, `05-tools/claude-code-tool-guide.md`
 - [X - Thariq](https://x.com/trq212)
-  - cited in: `05-tools/claude-code-tool-guide.md`
+  - cited in: `01-about-author/ai-people-to-follow.md`, `05-tools/claude-code-tool-guide.md`
 - [xAI – Grok](https://grok.x.ai/)
   - cited in: `05-tools/ai-tool-chaining-oct-2025.md`
 - [YouTube – AI agents overview](https://youtu.be/bx-bcUWw2Wo)


### PR DESCRIPTION
Add 01-about-author/ai-people-to-follow.md listing influential AI voices
to follow, grounded in references already cited across the repo plus a few
curated picks. Wire it into the mkdocs nav, the README quick links, and
register the new profile/home URLs in external-sources.md, then regenerate
source-index.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Du3eVjexSRV8ECwuZxTw4J