### PR TITLE
Add "10X Developer in the Agentic Era" guide (skills + metrics)

### DIFF
--- a/04-guides/10x-developer-agentic-era.md
+++ b/04-guides/10x-developer-agentic-era.md
@@ -1,0 +1,231 @@
+---
+title: "The 10X Developer in the Agentic Era — Skills and How to Measure Value"
+tags: ["guides", "ai-coding", "productivity", "metrics"]
+last_updated: "2026-06-29"
+---
+
+# The 10X Developer in the Agentic Era — Skills and How to Measure Value
+
+> "90% of Claude's mistakes come from missing context, not a weak model."
+> — Andrej Karpathy
+
+## Intent
+
+Define what makes a software developer genuinely high-leverage now that agents
+write, test, and refactor most of the code — and give engineering leaders a
+balanced way to measure that leverage as **value created for the company**,
+without rewarding the activity metrics (lines, commits, PR counts) that AI
+inflates.
+
+This guide has two halves:
+
+1. **The practitioner half** — the skills and habits that define the 10X
+   developer when generation is cheap.
+2. **The measurement half** — a metrics playbook that ties developer output to
+   business value using industry-standard frameworks (DORA, SPACE, DX Core 4)
+   plus agentic-era additions.
+
+## Use when
+
+- You are an engineering leader deciding **how to evaluate developers** whose
+  output is increasingly agent-produced.
+- You are an individual contributor asking **which skills still compound** when
+  AI can generate a feature in minutes.
+- You are building a **productivity dashboard** and need metrics that survive
+  contact with agentic workflows instead of being gamed by them.
+
+---
+
+## The shift in one sentence
+
+AI collapsed the cost of *producing* code, so value moved **from lines written
+to outcomes shipped and verified**. The scarce, valuable skills are now the ones
+agents are still bad at: judgment, system design, verification, taste, and
+knowing what *not* to build.
+
+This repo already names the progression. The
+[Prompt → Context → Harness → Loop](../02-ai-agents/01-foundations/prompt-context-harness-engineering.md)
+maturity scale describes a ladder of practitioners — **Prompter → Operator →
+Loop Engineer → System Architect** — where the unit of work grows from "one
+message" to "a population of loops across an org." The 10X developer of 2026 is
+not someone who types 10× faster; it is someone who **operates 10× more
+leverage** through agents while keeping the output trustworthy.
+
+| Old 10X developer | Agentic-era 10X developer |
+| :--- | :--- |
+| Writes more code, faster | Ships more *verified outcomes* per hour of direction + review |
+| Deep individual heroics | Designs the loop/harness so a team (and its agents) all improve |
+| Value ≈ personal output | Value ≈ leverage × quality × what compounds for others |
+| Measured by activity | Measured by throughput **and** stability **and** business impact |
+
+---
+
+## Part 1 — What defines the 10X developer now
+
+### 1. Judgment over generation
+
+The [12 Rules for AI Coding](ai-coding-rules-senior-engineers.md) tell the
+*model* to "use the model only for judgment calls." At the human level this
+inverts: the **developer's** unique value is judgment. Deciding what to build,
+spotting the wrong abstraction early, catching the silently-skipped 14% of
+records ("fail loud") — these are the moves agents cannot be trusted to make
+alone.
+
+### 2. Context and harness engineering
+
+Karpathy's line above is the whole game. The 10X developer turns tacit knowledge
+into **durable assets**: `CLAUDE.md` / `AGENTS.md` rules files, evals, tool
+wiring, and verification gates. The measurable proof that this compounds is in
+the rules-file data:
+
+| Setup | AI mistake rate |
+| :--- | :--- |
+| No rules file | 41% |
+| 4-rule baseline | 11% |
+| 12-rule version | 3% |
+
+A single shared rules file lifts *everyone's* mistake rate — that is the
+force-multiplier work, and it is nearly invisible to line-count metrics.
+
+### 3. Verification and taste at scale
+
+When an agent produces ten PRs, the bottleneck becomes review and trust. The
+high performer designs the loop — discover → plan → execute → verify → iterate —
+so that quality is enforced **automatically** (tests, checkpoints, CI gates)
+rather than re-reviewed by hand each time. See
+[Loop Engineering](../02-ai-agents/01-foundations/loop-engineering.md).
+
+### 4. Decomposition and orchestration
+
+Breaking a goal into agent-sized, independently-verifiable tasks is the
+Loop-Engineer / System-Architect skill: designing the assembly line, not
+hand-cranking each part.
+
+### 5. System and domain ownership
+
+Architecture, data modeling, security, and deep domain knowledge stay
+human-owned because they require **accountability** an agent cannot carry. As
+work scales to many concurrent loops, this becomes a governance problem — see
+[Agent Fleet Governance](../02-ai-agents/01-foundations/agent-fleet-governance.md).
+
+### 6. Compounding discipline over tool-chasing
+
+The sharpest line from the rules guide: *"These disciplines compound. A
+framework does not."* The 10X developer improves habits and assets, not just
+their tool of the month.
+
+> **Diagnostic:** if you removed this person, would the team's *agents* get
+> measurably worse — slower, lower acceptance, more incidents? If yes, you have
+> found a 10X developer. Their leverage lives in the system, not just their
+> own commits.
+
+---
+
+## Part 2 — How to measure value
+
+### The trap: activity metrics inflate under AI
+
+Lines of code, commit counts, and raw PR volume all rise when agents generate
+code — while saying nothing about whether that code shipped, survived, or
+created value. Never measure a developer by a single activity number; it
+rewards noise and is trivially gamed by an agent.
+
+### Backbone: industry-standard frameworks
+
+Use a balanced, team-level framework as the foundation:
+
+| Framework | What it measures | Why it matters here |
+| :--- | :--- | :--- |
+| **DORA** (4 keys) | Deployment frequency, lead time for changes, change-failure rate, MTTR | Captures throughput **and** stability — guards against "fast but breaks prod" |
+| **SPACE** | Satisfaction, Performance, Activity, Communication/collaboration, Efficiency/flow | Reminds you productivity is multidimensional; never reduce to one metric |
+| **DX Core 4** | Speed, Effectiveness, Quality, Business Impact | Current best "single dashboard" that rolls DORA + SPACE into four dimensions |
+
+### Layer: agentic-era metrics
+
+Add these on top to capture *leverage* specifically:
+
+- **AI leverage ratio** — verified output shipped per human-hour of *direction
+  + review* (not per line generated). This is the closest proxy for "how many
+  developers' worth of work is this person + their agents producing?"
+- **Acceptance / survival rate** — % of AI-generated code that is merged **and
+  still alive** after 30–90 days. Catches *churn*, a known failure mode where AI
+  output is generated and then deleted.
+- **Change-failure rate on AI-authored changes** — does the leverage hold
+  quality? Research warns that *perceived* speedup can exceed *real* speedup, so
+  measure outcomes, not feelings.
+- **Verification coverage** — % of agent output that passes automated gates
+  before a human review is needed.
+- **Compounding-asset creation** — count of rules files, evals, reusable
+  skills, and tools authored. The highest-leverage, least-visible work.
+- **Review throughput and latency** — increasingly the real bottleneck once
+  generation is cheap.
+
+### Translating metrics into business value
+
+| Metric moves… | …which creates company value by |
+| :--- | :--- |
+| Lead time ↓ | Getting validated features to market sooner (revenue speed) |
+| Change-failure rate ↓ / MTTR ↓ | Avoiding incident and rework cost |
+| AI leverage ratio ↑ | Unlocking capacity — one engineer + agents doing what took a team |
+| Compounding assets ↑ | An org-wide multiplier (the 41% → 3% effect, applied across N engineers) |
+| Code survival rate ↑ | Less wasted generation; output that actually sticks |
+
+### The recommended scorecard
+
+Measure value as a **throughput × quality grid, at the team level, over time** —
+never individual line counts.
+
+```text
+                 HIGH QUALITY                 LOW QUALITY
+            ┌───────────────────────┬───────────────────────┐
+HIGH        │  ★ 10X leverage        │  ⚠ Fast but fragile    │
+THROUGHPUT  │  ship fast + low CFR   │  high churn / incidents│
+            ├───────────────────────┼───────────────────────┤
+LOW         │  Careful but slow      │  ✗ Worst quadrant      │
+THROUGHPUT  │  safe, under-leveraged │  slow and breaks       │
+            └───────────────────────┴───────────────────────┘
+```
+
+Concretely, a defensible dashboard is:
+
+1. **DORA four keys** as the baseline (throughput + stability).
+2. **AI leverage ratio** and **code-survival rate** for agentic leverage.
+3. **A count of compounding assets** (rules files, evals, skills) created.
+4. **A qualitative SPACE check** (developer satisfaction, collaboration) so you
+   don't optimize people into burnout.
+
+> **Attribute to teams, not individuals.** AI makes individual attribution both
+> misleading (whose work is the agent's output?) and gameable. Team-level,
+> trend-over-time measurement is the honest unit.
+
+---
+
+## Anti-patterns to avoid
+
+- **Counting AI-generated lines as productivity.** It is a cost signal, not a
+  value signal.
+- **One-metric dashboards.** Any single number becomes a target and then stops
+  measuring anything (Goodhart's law).
+- **Individual leaderboards.** They reward gaming and punish the people who
+  invest in shared, compounding assets.
+- **Measuring speed without stability.** Throughput without change-failure rate
+  is how you ship fast into the "fast but fragile" quadrant.
+- **Ignoring survival.** Code that is generated and deleted a week later is
+  negative value disguised as velocity.
+
+## Related resources
+
+- [12 Rules for AI Coding Tools — Senior Engineer Edition](ai-coding-rules-senior-engineers.md) — the discipline that compounds
+- [From Prompt to Context to Harness Engineering](../02-ai-agents/01-foundations/prompt-context-harness-engineering.md) — the Prompter → System Architect maturity scale
+- [Loop Engineering (and How to Avoid Loopmaxxing)](../02-ai-agents/01-foundations/loop-engineering.md) — designing verifiable agent loops
+- [Agent Fleet Governance](../02-ai-agents/01-foundations/agent-fleet-governance.md) — accountability across many concurrent loops
+- [AI Coding Spectrum](../02-ai-agents/01-foundations/ai-coding-spectrum.md) — vibe → assisted → agentic coding modes
+- [LLM Lifecycle Monitoring Guide](llm-lifecycle-monitoring.md) — observability for AI-in-production
+
+## References
+
+- [DORA — DevOps Research and Assessment](https://dora.dev/) — the four key delivery metrics
+- [The SPACE of Developer Productivity (ACM Queue, 2021)](https://queue.acm.org/detail.cfm?id=3454124) — multidimensional productivity framework
+- [DX Core 4](https://getdx.com/research/measuring-developer-productivity-with-the-dx-core-4/) — unified speed/effectiveness/quality/business-impact model
+- https://karpathy.ai — source of the opening quote on context vs. model
+- [multica-ai/andrej-karpathy-skills](https://github.com/multica-ai/andrej-karpathy-skills) — the rules-file baseline behind the mistake-rate table

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Your guide to the Agentic AI evolution. **Prompting Blueprints** offers a curate
 
 ## 🆕 Recently added
 
-The five most recently added pages (auto-generated from git history — do not edit by hand):
+The ten most recently added pages (auto-generated from git history — do not edit by hand):
 
 <!-- RECENT_ADDITIONS:START -->
 - **2026-06-29** · [The 10X Developer in the Agentic Era — Skills and How to Measure Value](./04-guides/10x-developer-agentic-era.md)
@@ -25,6 +25,11 @@ The five most recently added pages (auto-generated from git history — do not e
 - **2026-06-27** · [Loop Engineering](./02-ai-agents/03-context-and-memory/loop-engineering.md)
 - **2026-06-26** · [Ornith-1.0: Run an Open-Source Agentic Coding LLM on a DGX Spark](./06-models-and-evaluations/ornith-1-0-dgx-spark-guide.md)
 - **2026-06-23** · [Banking AI Governance Use-Case Tutorial (Santander AI Open Source)](./07-use-cases-and-research/santander-ai-banking-governance.md)
+- **2026-06-23** · [Agent Fleet Governance (Fleet Engineering)](./02-ai-agents/01-foundations/agent-fleet-governance.md)
+- **2026-06-14** · [Build a Local Hermes Daily Assistant (Qwen3 + Ollama + Unsloth + Obsidian)](./05-tools/hermes-daily-assistant-setup.md)
+- **2026-06-14** · [Loop Engineering (and How to Avoid Loopmaxxing)](./02-ai-agents/01-foundations/loop-engineering.md)
+- **2026-06-09** · [GAISE 2026 — Conference Notes](./09-conferences/gaise-2026.md)
+- **2026-06-09** · [Requirements Engineering – Prompting Tips & Use Cases](./08-requirements-engineering/overview.md)
 <!-- RECENT_ADDITIONS:END -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Your guide to the Agentic AI evolution. **Prompting Blueprints** offers a curate
 The five most recently added pages (auto-generated from git history — do not edit by hand):
 
 <!-- RECENT_ADDITIONS:START -->
+- **2026-06-29** · [The 10X Developer in the Agentic Era — Skills and How to Measure Value](./04-guides/10x-developer-agentic-era.md)
 - **2026-06-29** · [AI People to Follow](./01-about-author/ai-people-to-follow.md)
 - **2026-06-27** · [Loop Engineering](./02-ai-agents/03-context-and-memory/loop-engineering.md)
 - **2026-06-26** · [Ornith-1.0: Run an Open-Source Agentic Coding LLM on a DGX Spark](./06-models-and-evaluations/ornith-1-0-dgx-spark-guide.md)
 - **2026-06-23** · [Banking AI Governance Use-Case Tutorial (Santander AI Open Source)](./07-use-cases-and-research/santander-ai-banking-governance.md)
-- **2026-06-23** · [Agent Fleet Governance (Fleet Engineering)](./02-ai-agents/01-foundations/agent-fleet-governance.md)
 <!-- RECENT_ADDITIONS:END -->
 
 ---
@@ -47,7 +47,7 @@ The five most recently added pages (auto-generated from git history — do not e
 
 Quick links: [Author's Speaking](./01-about-author/speaking) · [Author's Involvement](./01-about-author/program-committee) · [Author's Research](./01-about-author/research) · [AI Agents Overview](./02-ai-agents/01-foundations/ai-agents-overview.md) · [Context Engineering](./02-ai-agents/03-context-and-memory/context-engineering.md) · [Prompts & Patterns](./03-prompts-and-patterns) · [AI Guides Overview](./04-guides/overview.md) · [AI Tools](./05-tools) · [Models & Evaluations](./06-models-and-evaluations) · [Use-cases & Research](./07-use-cases-and-research) · [Requirements Engineering](./08-requirements-engineering/overview.md) · [Conferences (GAISE 2026)](./09-conferences/gaise-2026.md) · [External Sources](./external-sources.md) · [Source Index](./source-index.md) · [Changelog](./CHANGELOG.md)
 
-Featured additions: [Dynamic Context Discovery](./02-ai-agents/03-context-and-memory/cursor-dynamic-context-discovery.md) · [Vibe Coding Tech Stack](./04-guides/vibe-coding-tech-stack.md) · [Claude AI vs Code vs Cowork](./05-tools/claude-ai-vs-code-vs-cowork.md) · [Claude Code Project Structure](./05-tools/claude-code-project-structure-tutorial.md) · [Google 5-Day AI Agents Course](./02-ai-agents/01-foundations/google-5-day-ai-agents-course.md) · [Lyria 3 in Gemini](./05-tools/lyra-3-gemini.md)
+Featured additions: [The 10X Developer in the Agentic Era](./04-guides/10x-developer-agentic-era.md) · [Dynamic Context Discovery](./02-ai-agents/03-context-and-memory/cursor-dynamic-context-discovery.md) · [Vibe Coding Tech Stack](./04-guides/vibe-coding-tech-stack.md) · [Claude AI vs Code vs Cowork](./05-tools/claude-ai-vs-code-vs-cowork.md) · [Claude Code Project Structure](./05-tools/claude-code-project-structure-tutorial.md) · [Google 5-Day AI Agents Course](./02-ai-agents/01-foundations/google-5-day-ai-agents-course.md) · [Lyria 3 in Gemini](./05-tools/lyra-3-gemini.md)
 
 > Want more? Browse the publicly accessible [Google NotebookLM notebook](https://notebooklm.google.com/notebook/c486e20f-f02a-439c-8168-853472335263) for extended context, references, and drafts.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
     - Reasoning vs. Classic LLMs: 04-guides/reasoning-vs-classic-llms.md
     - Reasoning vs. Classic LLMs (DE): 04-guides/reasoning-vs-classic-llms-de.md
     - 12 Rules for AI Coding Tools (Senior Engineer Edition): 04-guides/ai-coding-rules-senior-engineers.md
+    - The 10X Developer in the Agentic Era (Skills + Metrics): 04-guides/10x-developer-agentic-era.md
     - Codex Agent Prompting Guide: 04-guides/codex-agent-prompting-guide.md
     - Codex TDD Workflow and Skills Guide: 04-guides/codex-tdd-and-skills.md
     - Fine-Tune an Open Source LLM with Claude: 04-guides/claude-fine-tune-llm.md

--- a/scripts/build-recent-additions.py
+++ b/scripts/build-recent-additions.py
@@ -2,7 +2,7 @@
 """
 Generate the "Recently added" list in README.md.
 
-The list shows the 5 most recently *added* content pages, derived automatically
+The list shows the 10 most recently *added* content pages, derived automatically
 from git history (the commit that first introduced each file). No manual
 bookkeeping is required: add a new content page, commit it, and the next run
 picks it up.
@@ -36,7 +36,7 @@ START = "<!-- RECENT_ADDITIONS:START -->"
 END = "<!-- RECENT_ADDITIONS:END -->"
 
 # How many recent additions to list.
-LIMIT = 5
+LIMIT = 10
 
 # Only markdown under the numbered content sections counts as a "new thing".
 CONTENT_GLOB = re.compile(r"^0\d-[^/]+/.*\.md$")


### PR DESCRIPTION
New 04-guides page defining the high-leverage developer when agents
produce most code, plus a measurement playbook (DORA, SPACE, DX Core 4
and agentic-era metrics) for tying output to business value. Registered
in mkdocs nav next to the senior-engineer coding rules.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QqWuFvrrpgAwjiKY2YU5GZ