### PR TITLE
ci: auto-refresh README "Recently added" list after commits in Claude sessions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r '.tool_input.command // \"\"'); case \"$cmd\" in *\"git commit\"*) python3 scripts/build-recent-additions.py >/dev/null 2>&1; if ! git diff --quiet -- README.md 2>/dev/null; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"scripts/build-recent-additions.py refreshed the README Recently added list; README.md now has uncommitted changes. Stage and commit README.md so the refresh is included in this change.\"}}'; fi ;; esac",
+            "statusMessage": "Refreshing README Recently added list"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ The ten most recently added pages (auto-generated from git history — do not ed
 - **2026-06-23** · [Agent Fleet Governance (Fleet Engineering)](./02-ai-agents/01-foundations/agent-fleet-governance.md)
 - **2026-06-14** · [Build a Local Hermes Daily Assistant (Qwen3 + Ollama + Unsloth + Obsidian)](./05-tools/hermes-daily-assistant-setup.md)
 - **2026-06-14** · [Loop Engineering (and How to Avoid Loopmaxxing)](./02-ai-agents/01-foundations/loop-engineering.md)
-- **2026-06-07** · [GAISE 2026 — Conference Notes](./09-conferences/gaise-2026.md)
-- **2026-06-03** · [From Prompt to Context to Harness Engineering](./02-ai-agents/01-foundations/prompt-context-harness-engineering.md)
+- **2026-06-10** · [GAISE 2026 — Conference Notes](./09-conferences/gaise-2026.md)
+- **2026-06-10** · [Requirements Engineering – Prompting Tips & Use Cases](./08-requirements-engineering/overview.md)
 <!-- RECENT_ADDITIONS:END -->
 
 ---


### PR DESCRIPTION
Add a PostToolUse hook (.claude/settings.json) that runs
scripts/build-recent-additions.py whenever Claude runs a git commit, then
nudges Claude to commit the refreshed README.md. The script derives the list
from committed git history, so the commit is the right trigger point. This
mirrors the existing recent-additions.yml CI for in-session work.

Also includes a refresh the script generated, picking up newer additions the
list had not yet reflected.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N8D2tg1WN34KfuomKw2EMz