### PR TITLE
Add SDLC traditional-vs-AI-powered illustration to vibe coding whitepaper mentions

### DIFF
--- a/02-ai-agents/01-foundations/prompt-context-harness-engineering.md
+++ b/02-ai-agents/01-foundations/prompt-context-harness-engineering.md
@@ -99,6 +99,8 @@ A practical extension of state and orchestration is **scheduling**: a built-in s
 
 The Kaggle/Google whitepaper **[The New SDLC with Vibe Coding](https://www.kaggle.com/whitepaper-the-new-SDLC-with-vibe-coding)** (Addy Osmani, Shubham Saboo, and Sokratis Kartakis, May 2026) devotes a section — *"Harness Engineering: What surrounds the model"* — to exactly this layer, and its framing is worth lifting wholesale.
 
+<img src="../../assets/google/sdlc_traditional_vs_ai_powered.png" alt="The New SDLC: the slow traditional way (weeks) vs the fast AI-powered way (minutes to hours) — same phases, time spent differently" width="80%">
+
 The whitepaper opens by naming a tempting but wrong intuition: *treating the model as the system.* A new model ships and the agent gets smarter; an older model and it gets worse — so the model becomes the explanation for everything good and bad. That instinct leads to the wrong investments. The model is **one input** into a running agent; everything else — the prompts, tools, context policies, hooks, sandboxes, sub-agents, and observability — is the **harness**, the scaffolding wrapped around the model that lets it actually *finish* something. The whitepaper compresses this into an equation:
 
 > **Agent = Model + Harness**

--- a/04-guides/overview.md
+++ b/04-guides/overview.md
@@ -10,6 +10,8 @@ These vendor guides are linked from their official sources rather than redistrib
 
 ## Guides Library
 - [Kaggle / Google: The New SDLC with Vibe Coding](https://www.kaggle.com/whitepaper-the-new-SDLC-with-vibe-coding) — Whitepaper by Addy Osmani, Shubham Saboo, and Sokratis Kartakis on how AI-assisted ("vibe coding") development reshapes the software development lifecycle, including the progression from prompt → context → **harness engineering**. Its *"Harness Engineering: What surrounds the model"* section is digested into the repo's [harness engineering tutorial](../02-ai-agents/01-foundations/prompt-context-harness-engineering.md). ([Google Drive mirror](https://drive.google.com/file/d/1wNEl8FMpTso8aXlb_joxgzparxi-0ciM/view))
+
+  <img src="../assets/google/sdlc_traditional_vs_ai_powered.png" alt="The New SDLC: the slow traditional way (weeks) vs the fast AI-powered way (minutes to hours) — same phases, time spent differently" width="80%">
 - [Gemini Prompting Guide 101](https://services.google.com/fh/files/misc/gemini-for-google-workspace-prompting-guide-101.pdf) — Core prompting patterns, guardrails, and examples for Gemini models. ([Google Workspace landing page](https://workspace.google.com/learning/content/gemini-prompt-guide))
 - [Google: Startup Technical Guide for AI Agents](https://services.google.com/fh/files/misc/startup_technical_guide_ai_agents_final.pdf) — Technical guide for startups building AI agents. ([Google Cloud landing page](https://cloud.google.com/resources/content/building-ai-agents))
 - [OpenAI: A Practical Guide to Building Agents](https://cdn.openai.com/business-guides-and-resources/a-practical-guide-to-building-agents.pdf) — Blueprint for designing agent workflows, orchestration, and evaluation.


### PR DESCRIPTION
## What changed

- Adds `assets/google/sdlc_traditional_vs_ai_powered.png`, a diagram contrasting the slow traditional SDLC (total time: weeks) with the fast AI-powered SDLC (total time: minutes to hours) — same phases, time spent differently.
- Embeds it in the two places where the Kaggle/Google whitepaper *The New SDLC with Vibe Coding* is substantively discussed:
  - `02-ai-agents/01-foundations/prompt-context-harness-engineering.md` — after the paragraph introducing the whitepaper in the "Agent = Model + Harness" section
  - `04-guides/overview.md` — under the whitepaper's Guides Library entry

## Why

The whitepaper references were text-only; the diagram illustrates the whitepaper's core thesis at a glance.

## Notes for reviewers

- Uses the repo's existing `<img src="..." width="80%">` embed convention with descriptive alt text.
- `source-index.md` and `external-sources.md` also mention the whitepaper but are pure link indexes, so they were left unchanged.
- The PNG is 4.8 MB, within the range of existing `assets/google/` files (up to 16 MB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)